### PR TITLE
fixing travis ci: use conda to install awscli

### DIFF
--- a/builders/travis/install.sh
+++ b/builders/travis/install.sh
@@ -21,7 +21,7 @@ else
     conda install -n testenv numpy=1.14
     source activate testenv
     pip install progressbar2
-    pip install awscli
+    conda install awscli
     # pip install coveralls
     # pip install codecov
 fi


### PR DESCRIPTION
travis ci cron test failed. looks like awscli failed to install using pip. try using conda