### PR TITLE
Bring back python2 support for popen

### DIFF
--- a/python/imars3d/shutils.py
+++ b/python/imars3d/shutils.py
@@ -1,21 +1,25 @@
-
 def exec_redirect_to_stdout(cmd, shell=False):
-    "execute a command in a subproces and redirect outputs (including errors) to sys.stdout"
+    """execute a command in a subproces and redirect outputs
+       (including errors) to sys.stdout"""
     import subprocess as sp, shlex, sys
     args = shlex.split(cmd)
     # sp.check_call(args, shell=shell)
     # manually pipe the output from the subprocess to sys.stdout so that
     # jupyter gets it inside the web page instead of the stdout of the terminal
     # from which jupyter is launched
+    kwargs = {}
+    if sys.version_info.major == 3:
+        kwargs['encoding'] = 'utf-8'
     p = sp.Popen(
         args,
         shell=shell,
         stdout=sp.PIPE,
         stderr=sp.STDOUT,
-        encoding='utf-8'
+        **kwargs
     )
 
-    # FIXME TODO : Popen API changes from python 2.7 to 3.6.  Require further work on this
+    # FIXME TODO : Popen API changes from python 2.7 to 3.6.
+    # Require further work on this
     # FIXME: skip output temporarily
     for c in iter(lambda: p.stdout.read(1), ''):
         if isinstance(c, str):
@@ -30,7 +34,7 @@ def exec_redirect_to_stdout(cmd, shell=False):
 
 
 def exec_withlog(cmd, logfile):
-    import subprocess as sp, shlex
+    import subprocess as sp, shlex, sys
     args = shlex.split(cmd)
     outstream = open(logfile, 'wt')
     outstream.write('%s\n\n' % cmd)
@@ -38,6 +42,7 @@ def exec_withlog(cmd, logfile):
     if sp.call(args, stdout=outstream, stderr=outstream, shell=False):
         outstream.close()
         log = open(logfile).read()
-        raise RuntimeError("%s failed. See log file %s\n%s\n" % (cmd, logfile, log))
+        raise RuntimeError("%s failed. See log file %s\n%s\n" % (cmd, logfile,
+                                                                 log))
     print(" - Done.")
     return


### PR DESCRIPTION
python2 does not support the `encoding` argument. This switches the behavior based on the version of python being used.