### PR TITLE
Make encoding only for python version < 3

### DIFF
--- a/python/imars3d/jnbui/_utils.py
+++ b/python/imars3d/jnbui/_utils.py
@@ -3,8 +3,29 @@
 import ipywidgets as ipyw
 from IPython.display import display, HTML, clear_output
 
+# standard
+import sys
+
 def js_alert(m):
     js = "<script>alert('%s');</script>" % m
     display(HTML(js))
     return
+
+
+def encode(message, encoding='utf-8'):
+    r"""
+    Convert to message to bytes for python 2.X, otherwise do not convert
+
+    Parameters
+    ----------
+    message : str
+    encoding : str
+
+    Returns
+    -------
+    str
+    """
+    if sys.version_info[0] < 3:
+        return message.encode(encoding=encoding)
+    return message
 

--- a/python/imars3d/jnbui/ct_wizard.py
+++ b/python/imars3d/jnbui/ct_wizard.py
@@ -1,5 +1,5 @@
 # coding: utf-8
-
+from ._utils import encode
 
 
 def wizard(config=None, context=None):
@@ -67,27 +67,27 @@ class WizardPanel:
     
 class InstrumentPanel(Panel):
 
-    instruments = dict(
-        # vulcan = 'sns',
-        snap = 'sns',
-        cg1d = 'hfir',
-        )
+    instruments = {
+        # vulcan: 'sns',
+        'snap': 'sns',
+        'cg1d': 'hfir',
+    }
     
     def __init__(self, context):
         self.context = context
-        explanation = ipyw.Label("Please chose the instrument", layout=self.label_layout)
+        explanation = ipyw.Label("Please choose the instrument", layout=self.label_layout)
         # self.text = ipyw.Text(value="CG1D", description="", placeholder="instrument name")
         self.text = ipyw.Select(value="CG1D", options=[i.upper() for i in self.instruments.keys()])
-        self.ok = ipyw.Button(description='OK', layout=self.button_layout)
-        self.ok.on_click(self.validate)
+        ok = ipyw.Button(description='OK', layout=self.button_layout)
+        ok.on_click(self.validate)
         skip = ipyw.Button(description="Skip", layout=self.button_layout)
         skip.on_click(self.skip)
-        buttons = ipyw.HBox(children=(self.ok, skip))
+        buttons = ipyw.HBox(children=(ok, skip))
         self.widgets = [explanation, self.text, buttons]
         self.panel = ipyw.VBox(children=self.widgets, layout=self.layout)
         
     def validate(self, s):
-        instrument = self.text.value.encode()
+        instrument = encode(self.text.value)
         if instrument.lower() not in self.instruments.keys():
             s = "instrument %s not supported!" % instrument
             js_alert(s)
@@ -125,7 +125,7 @@ class IPTSpanel(Panel):
         self.panel = ipyw.VBox(children=self.widgets, layout=self.layout)
         
     def validate_IPTS(self, s):
-        ipts1 = self.text.value.encode()
+        ipts1 = encode(self.text.value)
         facility = self.context.config.facility
         instrument = self.context.config.instrument
         path = os.path.abspath('/%s/%s/IPTS-%s' % (facility, instrument, ipts1))
@@ -177,7 +177,7 @@ class ScanNamePanel(Panel):
             s = 'Please specify a name for your tomography scan'
             js_alert(s)
         else:
-            self.context.config.scan = v.encode()
+            self.context.config.scan = encode(v)
             self.remove()
             wd_panel = WorkDirPanel(self.context, self.context.config.scan)
             wd_panel.show()
@@ -353,7 +353,7 @@ class CTDirPanel(Panel):
         self.panel = ipyw.VBox(children=self.widgets, layout=self.layout)
         
     def validate(self, s):
-        self.context.config.ct_subdir = self.select.value.encode()
+        self.context.config.ct_subdir = encode(self.select.value)
         self.remove()
         self.nextStep()
         return
@@ -427,7 +427,7 @@ class CTSigPanel(Panel):
         return ct_sig, sample
         
     def validate(self, s):
-        self.context.config.ct_sig = self.text.value.encode()
+        self.context.config.ct_sig = encode(self.text.value)
         self.remove()
         self.nextStep()
         return
@@ -483,7 +483,7 @@ class OBPanel(Panel):
         return files
         
     def validate(self, s):
-        v = [i.encode() for i in self.select.value]
+        v = [encode(i) for i in self.select.value]
         if not v:
             js_alert("Please select at least one OB file")
             return
@@ -578,7 +578,7 @@ class DFPanel(Panel):
         return files
         
     def validate(self, s):
-        v = [i.encode() for i in self.select.value]
+        v = [encode(i) for i in self.select.value]
         if not v:
             js_alert("Please select at least one DF file")
             return

--- a/python/imars3d/jnbui/tomoreconui.py
+++ b/python/imars3d/jnbui/tomoreconui.py
@@ -6,10 +6,11 @@ from .ct_wizard import Context, Config
 import os, time
 import ipywidgets as ipyw
 from IPython.display import display
-from ._utils import js_alert
+from ._utils import js_alert, encode
 from ipywe import imageslider as ImgSlider, fileselector as flselect
 import pickle as pkl
 import logging; logger = logging.getLogger('ui')
+
 
 class UIConfig:
     img_width = 0
@@ -19,11 +20,13 @@ class UIConfig:
     smooth_projection = False
     start_directory = None
 
+
 def createContext():
     context = Context()
     config = Config()
     context.config = config
     return context
+
 
 def wizard(context, start_dir=os.path.expanduser("~"), image_width=300, image_height=300, remove_rings_at_sinograms=False, smooth_rec=False, smooth_proj=False):
     """
@@ -94,6 +97,7 @@ class StartButtonPanel(base.Panel):
             Object (from ct_wizard.py) that stores the config
             and ct objects used in the reconstruction process   
         """
+
         self.context = context
         explanation = ipyw.Label("Do you wish to start from scratch or use a previous reconstruction configuration?", layout=self.label_layout)
         scratch_button = ipyw.Button(description="Start from Scratch",
@@ -198,7 +202,7 @@ class InstrumentPanel(base.InstrumentPanel):
     """
 
     def validate(self, s):
-        instrument = self.text.value.encode()
+        instrument = encode(self.text.value)
         if instrument.lower() not in self.instruments.keys():
             s = "instrument {} not supported!".format(instrument)
             js_alert(s)
@@ -219,7 +223,7 @@ class IPTSpanel(base.IPTSpanel):
     """
 
     def validate_IPTS(self, s):
-        ipts1 = self.text.value.encode()
+        ipts1 = encode(self.text.value)
         facility = self.context.config.facility
         instrument = self.context.config.instrument
         path = os.path.abspath('/{0}/{1}/IPTS-{2}'.format(facility, instrument, ipts1))
@@ -255,7 +259,7 @@ class ScanNamePanel(base.ScanNamePanel):
             s = 'Please specify a name for your tomography scan'
             js_alert(s)
         else:
-            self.context.config.scan = v.encode()
+            self.context.config.scan = encode(v)
             self.remove()
             wd_panel = WorkDirPanel(self.context, self.context.config.scan)
             wd_panel.show()
@@ -349,7 +353,8 @@ class DFPanel(base.DFPanel):
         # create output dir and move over there
         os.makedirs(self.context.config.outdir)
         os.chdir(self.context.config.outdir)
-        assert os.getcwd() == self.context.config.outdir
+        assert os.getcwd() == self.context.config.outdir, \
+            'Current directory {} is not selected outdir {}'.format(os.getcwd(), self.context.config.outdir)
         # copy imars3d config if it exists
         if os.path.exists(orig_imars3d_config):
             import shutil


### PR DESCRIPTION
**Description of Work:**  
- [x] Utility function for encoding a string when python version < 3
- [x] substitute the calls to `str.encode()` method with the utility function
 
