### PR TITLE
migrate to python 3.8 and tomopy 1.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,12 +39,9 @@ $ cd /path/to/imars3d; python setup.py install
 Using `mamba` instead of `conda`.  
 First create the environment and install iMars3D dependencies, except for `ipywe`:  
 ```bash
-mamba create --name imars3d python=3.5
+mamba create --name imars3d python=3.8
 conda activate imars3d
-mamba install pytest pyyaml numpy scipy matplotlib astropy mpi4py psutil scikit-image
-mamba install -c dgursoy tomopy=0.1.15
-mamba install dxchange
-mamba install progressbar2
+mamba install pytest pyyaml numpy scipy matplotlib astropy mpi4py mpich psutil scikit-image tomopy dxchange progressbar2
 ```
 Install `ipywe` dependencies with this [requirements.txt](https://github.com/ornlneutronimaging/iMars3D/files/7338852/requirements.txt)
  file.

--- a/python/imars3d/ImageFileSeries.py
+++ b/python/imars3d/ImageFileSeries.py
@@ -8,9 +8,8 @@ class ImageFileSeries(base):
     """Represent a series of image files. 
     For example, a series of cif files or a series of tiff files.
     """
-    
-    
-    def __init__(self, filename_template, 
+
+    def __init__(self, filename_template,
                  identifiers=None, decimal_mark_replacement="_", mode="r", name=None):
         """
         filename_template: examples 2014*_CT*_%07.3f_*.fits
@@ -21,7 +20,6 @@ class ImageFileSeries(base):
         self._init(filename_template, identifiers, decimal_mark_replacement, mode, name)
         return
 
-
     def __getstate__(self):
         return dict(
             name = self.name,
@@ -31,10 +29,8 @@ class ImageFileSeries(base):
             decimal_mark_replacement = self.decimal_mark_replacement
             )
 
-
     def __setstate__(self, state):
         return self._init(**state)
-
 
     def _init(self, filename_template=None,
               identifiers=None, decimal_mark_replacement="_", mode="r", name=None):
@@ -49,23 +45,19 @@ class ImageFileSeries(base):
         if identifiers is None:
             identifiers = []
         base.__init__(self, mode=mode, identifiers=identifiers, name=name)
-        
         self.filename_template = filename_template
         self.decimal_mark_replacement = decimal_mark_replacement
         return
 
-    
     def getslice(self, s):
         return self.__class__(
             self.filename_template, self.identifiers[s],
             self.decimal_mark_replacement, self.mode, self.name)
 
-    
     def getImage(self, identifier):
         p = self.getFilename(identifier)
         return ImageFile(p)
-    
-        
+
     def getFilename(self, identifier):
         path_pattern = self._getPathpattern(identifier)
         # don't need to check if file exists if we are creating it
@@ -84,16 +76,14 @@ class ImageFileSeries(base):
                 self.filename_template, path_pattern, identifier, pathlist)
             import warnings
             warnings.warn(msg)
-    
+
         path = paths[0]
         return path
-    
-    
+
     def exists(self, identifier):
         assert self.mode == 'w'
         p = self._getPathpattern(identifier)
         return os.path.exists(p)
-
 
     def putImage(self, identifier, data):
         p = self._getPathpattern(identifier)
@@ -101,7 +91,6 @@ class ImageFileSeries(base):
         img.data = data
         img.save()
         return
-
 
     def removeAll(self):
         """remove all image files"""
@@ -112,7 +101,6 @@ class ImageFileSeries(base):
             continue
         return
 
-
     def _getPathpattern(self, identifier):
         path_pattern = self.filename_template % (identifier,)
         dir = os.path.dirname(path_pattern)
@@ -122,12 +110,11 @@ class ImageFileSeries(base):
         path_pattern = os.path.join(
             dir, base.replace(".", self.decimal_mark_replacement) + ext)
         return path_pattern
-    
-    
+
 
 def imageCollection(glob_pattern=None, name=None, files=None):
     """create an ImageFileSeries instance from a collection of image files
-    
+
     This is intended for a bunch of images that cannot otherwise be identified.
     This is useful for, for example, dark field images and open beam images,
     which really do not need individual access but rather a way to iterate

--- a/python/imars3d/__init__.py
+++ b/python/imars3d/__init__.py
@@ -11,7 +11,7 @@ import yaml, os
 conf_path = "imars3d.conf"
 config = dict()
 if os.path.exists(conf_path):
-    config = yaml.load(open(conf_path))
+    config = yaml.safe_load(open(conf_path))
 # logging config
 import logging.config
 logging_conf = config.get("logging")

--- a/python/imars3d/recon/mpi.py
+++ b/python/imars3d/recon/mpi.py
@@ -111,13 +111,15 @@ parallalization. sth similar to $ mpirun -np NODES python "code to call this met
         stop1 = min(start + stepsize, stop)
         logger.debug("node %s of %s working on %s:%s" % (rank, size, start, stop1))
         sinograms1 = sinograms[start:stop1]
-        if not len(sinograms):
+        if not len(sinograms1):
             continue
         recon_series1 = recon_series[start:stop1]
         try:
             recon(sinograms1, theta, recon_series1, center=center, **kwds)
         except:
-            logger.info("node %s of %s: recon %s:%s failed" % (rank, size, start, stop1))
+            import traceback as tb
+            err = tb.format_exc()
+            logger.info("node %s of %s: recon %s:%s failed:\n%s" % (rank, size, start, stop1, err))
 
         # update range
         start = stop1

--- a/python/imars3d/recon/mpi.py
+++ b/python/imars3d/recon/mpi.py
@@ -39,11 +39,14 @@ recon_mpi(**kargs)
     kargs_pkl = os.path.join(dir, "kargs.pkl")
     kargs = dict(sinograms=sinograms, theta=theta, recon_series=recon_series)
     kargs.update(kwds)
-    pickle.dump(kargs, open(kargs_pkl, 'wb'))
+    with open(kargs_pkl, 'wb') as ostream:
+        pickle.dump(kargs, ostream)
     # write python code
     pycode = py_code_template % locals()
     pyfile = os.path.join(dir, "recon.py")
-    open(pyfile, 'wt').write(pycode)
+    with open(pyfile, 'wt') as ostream:
+        ostream.write(pycode)
+    # print(kargs_pkl, pyfile)
     # cpus
     if not nodes:
         import psutil
@@ -70,21 +73,19 @@ parallalization. sth similar to $ mpirun -np NODES python "code to call this met
     """
     import logging; logger = logging.getLogger("mpi")
     import imars3d.io
-    
+
     from mpi4py import MPI
     comm = MPI.COMM_WORLD
     size = comm.Get_size()
     rank = comm.Get_rank()
-    
     totalN = len(sinograms)
+
     N = int(np.ceil(totalN*1. / size))
     start, stop = rank*N, min(totalN, (rank+1)*N)
-    # print("node %s of %s handles %s" % (rank, size, layers))
-    # print("N, start, stop=%s, %s, %s" % (N, start, stop))
-
+    print("node %s of %s handles [%s--%s] of %s" % (rank, size, start, stop, totalN))
     if recon is None:
         from .use_tomopy import recon_batch_singlenode as recon
-    
+
     # progress bar
     # for simplicity, we just report the progress at rank 0, which should be a
     # good indication of progress of all nodes any way

--- a/python/imars3d/recon/use_tomopy.py
+++ b/python/imars3d/recon/use_tomopy.py
@@ -25,6 +25,7 @@ This is intended to be run on just one node.
     # algorithm='fbp',
     # lgorithm='pml_hybrid',
     # TODO FIXME - removed emission in tomopy.recon.  need to verify
+    proj = tomopy.minus_log(proj)
     rec = tomopy.recon(
         proj,
         theta=theta, center=center,

--- a/tests/imars3d/detector_correction/test_fix_dead_pixels.py
+++ b/tests/imars3d/detector_correction/test_fix_dead_pixels.py
@@ -6,11 +6,12 @@ import numpy as np
 
 from imars3d import detector_correction
 
+thisdir = os.path.dirname(__file__)
 
 def test_retrieving_low_and_high_resolution_dead_pixels():
     
     # init final image
-    detector_config = './python/imars3d/config/detector_dead_pixels.yml'
+    detector_config = os.path.join(thisdir, '../../../python/imars3d/config/detector_dead_pixels.yml')
     
     # retrieve dead pixel values
     dead_pixels = detector_correction.retrieve_mcp_dead_pixels.RetrieveMCPDeadPixels(detector_config)

--- a/tests/imars3d/recon/test_mpi.py
+++ b/tests/imars3d/recon/test_mpi.py
@@ -73,8 +73,8 @@ from imars3d.recon.mpi import recon_mpi
 recon_mpi(sinograms, theta, recon_series, stepsize=1)
 """
     pypath = os.path.join(outdir, "test_recon_mpi_2cpu.py")
-    open(pypath, 'wt').write(pycode)
-    
+    with open(pypath, 'wt') as ostream:
+        ostream.write(pycode)
     cmd = "mpirun -np 2 python %s" % pypath
     if os.system(cmd):
         raise RuntimeError("%s failed" % cmd)

--- a/tests/imars3d/test_components.py
+++ b/tests/imars3d/test_components.py
@@ -1,6 +1,10 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+# This test script is to be run manually.
+# To test, uncomment the test functions in main() method one by one.
+# For the last test "test_recon", need to modify the "sinograms" variable below.
+
 # tell pytest to skip this test
 import pytest
 pytestmark = pytest.mark.skipif(True, reason="need large dataset")
@@ -56,13 +60,14 @@ intfluct_corrected_series = imars3d.io.ImageFileSeries(
 sinograms = imars3d.io.ImageFileSeries(
     os.path.join(outdir, "sinogram_%i.tiff"),
     name = "Sinogram", mode = 'w',
+    # uncomment the following when running test_con
+    # identifiers = range(1978)
 )
 # reconstructed
 recon_series = imars3d.io.ImageFileSeries(
     os.path.join(outdir, "recon_%i.tiff"),
     name = "Reconstructed", mode = 'w',
 )
-
 
 def test_gamma_filter():
     # output
@@ -113,13 +118,15 @@ def test_projection():
 def test_recon():
     from imars3d.recon.mpi import recon
     recon_series.identifiers = sinograms.identifiers
+    # recon(sinograms[:2], theta, recon_series, nodes=1)
+    # recon(sinograms[:20], theta, recon_series, nodes=5)
     recon(sinograms, theta, recon_series, nodes=20)
     return
 
 
 def main():
-    # test_gamma_filter()
-    test_normalization()
+    test_gamma_filter()
+    # test_normalization()
     # test_tiltcalc()
     # test_tiltcorr()
     # test_correct_intensity_fluctuation()


### PR DESCRIPTION
This branch is intended to restore the tests for imars3d. It was tested on my ubuntu box and the following two tests passed running from the root dir of the repo:

```
py.test
python tests/workflows/recon/test_CT_travisCI.py 
```

The test data needed were copied from /SNS/users/lj7/dv/imaging/iMars3D/tests/iMars3D_data_set

Here is the installation instruction:
```
conda config --add channels conda-forge
conda create --name imars3d python=3.8
conda activate imars3d
conda install pytest pyyaml numpy scipy matplotlib astropy mpi4py mpich psutil scikit-image tomopy dxchange progressbar2 ipywe
python setup.py develop
```
