### PR TITLE
[IMG123] Add developer documentations

### DIFF
--- a/dev_docs/Makefile
+++ b/dev_docs/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = .
+BUILDDIR      = _build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/dev_docs/conf.py
+++ b/dev_docs/conf.py
@@ -1,0 +1,55 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# This file only contains a selection of the most common options. For a full
+# list see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Path setup --------------------------------------------------------------
+
+# If extensions (or modules to document with autodoc) are in another directory,
+# add these directories to sys.path here. If the directory is relative to the
+# documentation root, use os.path.abspath to make it absolute, like shown here.
+#
+# import os
+# import sys
+# sys.path.insert(0, os.path.abspath('.'))
+
+
+# -- Project information -----------------------------------------------------
+
+project = 'iMars3D Developer Documentation'
+copyright = '2022, SCSE@ORNL'
+author = 'SCSE@ORNL'
+
+
+# -- General configuration ---------------------------------------------------
+
+# Add any Sphinx extension module names here, as strings. They can be
+# extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
+# ones.
+extensions = [
+    'sphinx.ext.autodoc',
+    'sphinx.ext.doctest',
+    'sphinx.ext.mathjax',
+]
+
+# Add any paths that contain templates here, relative to this directory.
+templates_path = ['_templates']
+
+# List of patterns, relative to source directory, that match files and
+# directories to ignore when looking for source files.
+# This pattern also affects html_static_path and html_extra_path.
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+
+
+# -- Options for HTML output -------------------------------------------------
+
+# The theme to use for HTML and HTML Help pages.  See the documentation for
+# a list of builtin themes.
+#
+html_theme = 'alabaster'
+
+# Add any paths that contain custom static files (such as style sheets) here,
+# relative to this directory. They are copied after the builtin static files,
+# so a file named "default.css" will overwrite the builtin "default.css".
+html_static_path = ['_static']

--- a/dev_docs/dev_process/overview.rst
+++ b/dev_docs/dev_process/overview.rst
@@ -1,0 +1,52 @@
+========
+Overview
+========
+
+.. contents::
+    :local:
+
+
+Developer Account
+-----------------
+
+All the development work is done via Github, and the developers working on iMars3D must have a valid Github account with 2-step authentication enabled.
+For developers who are part of SCSE@ORNL, please contact a senior developer to add you to the project.
+
+
+Branches
+--------
+
+The default branch for development is ``next``, where all feature branches should be based on and all pull requests should be merged into.
+Both ``main`` and ``qa`` branches are protected, and regular developers should not touch these branches unless instructed by a senior developer.
+
+
+Development Cycle
+-----------------
+
+For developers who are part of SCSE@ORNL, the development cycle is as follows:
+
+* Checkout a new branch based from ``next`` with a new branch name that contains the internal issue reference number.
+* Working on the issue and making changes to the code.
+* Make sure all tests are passing locally and new tests should be added to the test suite when introducing new features.
+* Make a pull request to the ``next`` branch:
+
+  * The title of the pull request should contain both the reference issue number and a brief description of the issue.
+  * A link to the internal issue/task/story page should be provided at the top of the description.
+  * Select a reviewer for the pull request.
+  * Once the pull request is approved and all threads are resolved, ping the senior developers to merge the pull request.
+
+
+It is recommended to use ``git rebase`` to clean-up the commit history before making a pull request as it will help keep the git history easy to search.
+
+
+For independent contributors, the recommended development cycle is as follows:
+
+* Open an issue to describe the motivation for the feature/bug fix/etc.
+* Fork the repository and implement the features and bug fixes.
+* Make sure all tests are passing locally and new tests should be added to the test suite when introducing new features.
+* Make a pull request to the ``next`` branch:
+
+  * Reference the previously opened issue that motivates this PR at the top of the description.
+  * The title of the pull request should be concise and meaningful.
+  * Select a reviewer for the pull request.
+  * Once the pull request is approved, ping a developer from the list for merging.

--- a/dev_docs/dev_process/overview.rst
+++ b/dev_docs/dev_process/overview.rst
@@ -50,3 +50,16 @@ For independent contributors, the recommended development cycle is as follows:
   * The title of the pull request should be concise and meaningful.
   * Select a reviewer for the pull request.
   * Once the pull request is approved, ping a developer from the list for merging.
+
+
+Release Cycle
+-------------
+
+
+At the beginning of every iteration (two weeks), a senior developer on duty will tag the current ``next`` branch as a new ``qa`` branch.
+A auto pipeline will be triggered to deploy the new ``qa`` branch to a testing server where the computational instrument scientists (CIS) will test the newly added features as well as bug fixes.
+Once the final approval from CIS team is given, this ``qa`` branch will be merged into ``main`` branch.
+At the beginning of every month, a auto pipeline will tag the current ``main`` if there are new features or bug fixes, along with publishing the new version to the production server for general users to use.
+
+By default, the ``next`` branch is published to a conda channel called ``neutronimaging`` whenever a feature branch is merged into ``next``.
+Similarly, the tagging of ``main`` will trigger the pipeline to publish the stable version of ``iMars3D`` to both ``conda-forge`` as well as ``PyPI``.

--- a/dev_docs/index.rst
+++ b/dev_docs/index.rst
@@ -1,0 +1,28 @@
+.. iMars3D Developer Documentation documentation master file, created by
+   sphinx-quickstart on Mon Mar 21 16:01:24 2022.
+   You can adapt this file completely to your liking, but it should at least
+   contain the root `toctree` directive.
+
+Welcome to iMars3D Developer Documentation's documentation!
+===========================================================
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`
+
+
+Development Process
+===================
+
+.. toctree::
+   :maxdepth: 2
+
+   dev_process/overview

--- a/dev_docs/make.bat
+++ b/dev_docs/make.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=.
+set BUILDDIR=_build
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.http://sphinx-doc.org/
+	exit /b 1
+)
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,1 +1,252 @@
 _build
+dev_docs/_build/*
+
+# Created by https://www.toptal.com/developers/gitignore/api/python,macos,linux,windows,visualstudiocode
+# Edit at https://www.toptal.com/developers/gitignore?templates=python,macos,linux,windows,visualstudiocode
+
+### Linux ###
+*~
+
+# temporary files which can be created if a process still has a handle open of a deleted file
+.fuse_hidden*
+
+# KDE directory preferences
+.directory
+
+# Linux trash folder which might appear on any partition or disk
+.Trash-*
+
+# .nfs files are created when an open file is removed but is still being accessed
+.nfs*
+
+### macOS ###
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+### Python ###
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/
+
+### VisualStudioCode ###
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+!.vscode/*.code-snippets
+
+# Local History for Visual Studio Code
+.history/
+
+# Built Visual Studio Code Extensions
+*.vsix
+
+### VisualStudioCode Patch ###
+# Ignore all local history of files
+.history
+.ionide
+
+# Support for Project snippet scope
+
+### Windows ###
+# Windows thumbnail cache files
+Thumbs.db
+Thumbs.db:encryptable
+ehthumbs.db
+ehthumbs_vista.db
+
+# Dump file
+*.stackdump
+
+# Folder config file
+[Dd]esktop.ini
+
+# Recycle Bin used on file shares
+$RECYCLE.BIN/
+
+# Windows Installer files
+*.cab
+*.msi
+*.msix
+*.msm
+*.msp
+
+# Windows shortcuts
+*.lnk
+
+# End of https://www.toptal.com/developers/gitignore/api/python,macos,linux,windows,visualstudiocode


### PR DESCRIPTION
- Original Gitlab Task: [IMG123](https://code.ornl.gov/sns-hfir-scse/imaging/imaging/-/issues/123)

This PR introduces the following changes:

- update git ignore list for repo management
- add new folder `dev-docs` to store developer documentation
- add overview page for developer documentation.

The developer documentation is build with `sphinx`, and the html version can be built by running `make html` inside `dev_docs`.