### PR TITLE
[IMG156] add intensity fluctuation correction filter for imar3d_v2

### DIFF
--- a/src/imars3dv2/filters/intensity_fluctuation_correction.py
+++ b/src/imars3dv2/filters/intensity_fluctuation_correction.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+import numpy as np
+import tomopy
+import tomopy.util.mproc as mproc
+from skimage import feature
+import concurrent.futures as cf
+
+
+def intensity_fluctuation_correction(
+    arrays: np.ndarray,
+    air_pixels: int = 5,
+    sigma: int = 3,
+    ncore: int = -1,
+):
+    """
+    Correct for intensity fluctuation in the radiograph.
+
+    Parameters
+    ----------
+    @param arrays:
+        The image/radiograph stack to correct for beam intensity fluctuation.
+    @param air_pixels:
+        Number of pixels at each boundary to calculate the scaling factor. When a negative number
+        is given, the auto air region detection will be used instead of tomopy.
+    @param sigma:
+        The standard deviation of the Gaussian filter, only valid when using the auto air region
+        detection via canny edge detection from skimage.
+    @param ncore:
+        The number of cores to use for parallel processing, default is -1, which means using all available cores.
+
+    Returns
+    -------
+    @return:
+        The corrected image/radiograph stack.
+    """
+    # validation
+    if arrays.ndim not in (2, 3):
+        raise ValueError("The image/radiograph stack must be 2D or 3D.")
+    # process
+    if air_pixels < 0:
+        # auto air region detection
+        ncore = mproc.mp.cpu_count() if ncore == -1 else int(ncore)
+        with cf.ProcessPoolExecutor(ncore) as e:
+            jobs = [
+                e.submit(
+                    intensity_fluctuation_correction_skimage,
+                    image,
+                    sigma,
+                )
+                for image in arrays
+            ]
+        return np.array([job.result() for job in jobs])
+    else:
+        # use tomopy process
+        ncore = None if ncore == -1 else int(ncore)
+        return tomopy.normalize_bg(arrays, air=air_pixels, ncore=ncore)
+
+
+def intensity_fluctuation_correction_skimage(
+    image: np.ndarray,
+    sigma: int = 3,
+):
+    """
+    Correct for intensity fluctuation in the radiograph using skimage to auto
+    detect the air region (adapted from iMars3dv1.filter.ifc).
+
+    Parameters
+    ----------
+    @param image:
+        The image/radiograph (2D) to correct for beam intensity fluctuation.
+    @param sigma:
+        The standard deviation of the Gaussian filter for the canny edge detection.
+
+    Returns
+    -------
+    @return:
+        The corrected image/radiograph (2D).
+    """
+    # get boundary
+    edge = feature.canny(image, sigma=sigma)
+    start_row = None
+    middle_col = (edge.shape[1] - 1) // 2
+    start_cols = np.ones(edge.shape[0], dtype=int) * middle_col
+    stop_cols = np.ones(edge.shape[0], dtype=int) * middle_col
+    for i, row in enumerate(edge):
+        isedge = row > 0
+        if isedge.any():
+            w = np.where(isedge)[0]
+            start_cols[i], stop_cols[i] = w[0], w[-1]
+            # set the row that starts to have object to be measured
+            if start_row is None:
+                start_row = i
+    # get background
+    _, NCOLS = image.shape
+    start_cols = start_cols // 2
+    stop_cols = (stop_cols + NCOLS) // 2
+    # compute bg
+    left = None
+    right = None
+    for i, row in enumerate(image):
+        _left = row[: start_cols[i]]
+        _right = row[stop_cols[i] :]
+        if left is None:
+            left = _left
+        else:
+            left = np.concatenate((left, _left))
+        if right is None:
+            right = _right
+        else:
+            right = np.concatenate((right, _right))
+    factor = np.concatenate((left, right)).mean()
+    # apply the correction factor
+    return image / factor

--- a/src/imars3dv2/filters/intensity_fluctuation_correction.py
+++ b/src/imars3dv2/filters/intensity_fluctuation_correction.py
@@ -64,6 +64,12 @@ def intensity_fluctuation_correction_skimage(
     """
     Correct for intensity fluctuation in the radiograph using skimage to auto
     detect the air region (adapted from iMars3dv1.filter.ifc).
+    NOTE:
+    This method here is assuming the beam is decaying uniformly over time whereas
+    the tomopy version is assuming different region decays slightly different, hence
+    the linear interpolation between left and right air pixels.
+    In most cases, a uniform decay is a good approximation as neutron beam tends
+    to be very stable.
 
     Parameters
     ----------
@@ -78,37 +84,64 @@ def intensity_fluctuation_correction_skimage(
         The corrected image/radiograph (2D).
     """
     # get boundary
+    # NOTE:
+    #   1. Use canny edge detection to get a binary mask indicating which pixels is
+    #   edge.
+    #   2. If the background is somewhat noisy, the canny edge detection will always
+    #   mark at least the second outmost ring of pixels as edge, therefore we will
+    #   have at least one air pixels to work with, which is consistent with the
+    #   default air=1 from tomopy.normalize_bg
     edge = feature.canny(image, sigma=sigma)
-    start_row = None
+    # Find the middle col position, for a 512x512 image, this would be 255
     middle_col = (edge.shape[1] - 1) // 2
+    # Use the middle col as starting guess for the left and right bound for each
+    # row, we will move it to the left and right as we go through each row in the
+    # image, i.e. finding the rough contour of the object.
     start_cols = np.ones(edge.shape[0], dtype=int) * middle_col
     stop_cols = np.ones(edge.shape[0], dtype=int) * middle_col
     for i, row in enumerate(edge):
+        # here we are checking if there is any pixel marked to be an edge (True)
+        # if there is at least one pixel, we will start moving the left and right
+        # bound, otherwise we will keep them at the middle col, i.e. using the
+        # whole row as the air pixels.
         isedge = row > 0
         if isedge.any():
             w = np.where(isedge)[0]
+            # mark the first edge pixel to be the new left bound for current row,
+            # and the last edge pixel to be the new right bound.
             start_cols[i], stop_cols[i] = w[0], w[-1]
-            # set the row that starts to have object to be measured
-            if start_row is None:
-                start_row = i
     # get background
-    _, NCOLS = image.shape
+    _, n_cols = image.shape
+    # Instead of blindly trusting the contour derived from canny edge detection,
+    # we are using the middle pixel between the bound and the edge of the image
+    # as the bound of the object.
+    # For example, at row x from a image of 128x128, canny edge detection shows
+    # the left bound is at 12 and right bound is at 120, we will move the two
+    # bounds closer to the edge, i.e 6 as the new left bound, and 124 as the
+    # right bound.
     start_cols = start_cols // 2
-    stop_cols = (stop_cols + NCOLS) // 2
+    stop_cols = (stop_cols + n_cols) // 2
     # compute bg
-    left = None
-    right = None
+    # NOTE: We are gathering all pixels considered to be air pixels row by row.
+    #       For example, in a image of 3x10 with left and right bounds at
+    #       3, 8
+    #       1, 7,
+    #       2, 8
+    #       the final collection of air pixels (1D array) will be
+    #       [ img[0,0], img[0,1], img[0,2],
+    #         img[1,0],
+    #         img[2,0], img[2,1],
+    #         img[0,7], img[0,8], img[0,9],
+    #         img[1,6], img[1,7], img[1,8], img[1,9],
+    #         img[0,7], img[0,8], img[0,9],
+    #       ]
+    #       the average value of the 1D array above will be used to normalize
+    #       the corresponding image.
+    left = np.array([])
+    right = np.array([])
     for i, row in enumerate(image):
-        _left = row[: start_cols[i]]
-        _right = row[stop_cols[i] :]
-        if left is None:
-            left = _left
-        else:
-            left = np.concatenate((left, _left))
-        if right is None:
-            right = _right
-        else:
-            right = np.concatenate((right, _right))
+        left = np.concatenate((left, row[: start_cols[i]]))
+        right = np.concatenate((right, row[stop_cols[i] :]))
     factor = np.concatenate((left, right)).mean()
     # apply the correction factor
     return image / factor

--- a/tests/unit/filters/test_intensity_fluctuation_correction.py
+++ b/tests/unit/filters/test_intensity_fluctuation_correction.py
@@ -64,7 +64,7 @@ def test_correct_with_tomopy():
     # generate the corresponding flickering projections
     projs_flickering = generate_flickering_projections(projs_ideal)
     # perform correction
-    projs_corrected = intensity_fluctuation_correction(projs_flickering)
+    projs_corrected = intensity_fluctuation_correction(projs_flickering, air_pixels=5)
     # verify
     # NOTE: after the correction, the air region within each sinogram should be
     #       close to uniform, therefore should result in smaller variance when
@@ -75,10 +75,22 @@ def test_correct_with_tomopy():
 
 
 def test_correct_with_imars3d():
-    # NOTE:
-    #  The original imars3d method's logic is unclear, therefore cannot be verified
-    #  at the moment.
-    pass
+    # get synthetic projections
+    projs_ideal = generate_fake_projections()
+    # generate the corresponding flickering projections
+    projs_flickering = generate_flickering_projections(projs_ideal)
+    # perform correction with skimage
+    projs_corrected = intensity_fluctuation_correction(projs_flickering, air_pixels=-1)
+    # verify
+    diff_raw = projs_flickering - projs_ideal
+    diff_corrected = projs_corrected - projs_ideal
+    assert diff_corrected.var() < diff_raw.var()
+
+
+def test_incorrect_input_array():
+    projs_incorrect = np.array([1, 2, 3])
+    with pytest.raises(ValueError):
+        intensity_fluctuation_correction(projs_incorrect, air_pixels=5)
 
 
 if __name__ == "__main__":

--- a/tests/unit/filters/test_intensity_fluctuation_correction.py
+++ b/tests/unit/filters/test_intensity_fluctuation_correction.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+import numpy as np
+import pytest
+import tomopy
+from imars3dv2.filters.intensity_fluctuation_correction import intensity_fluctuation_correction
+
+np.random.seed(0)
+
+
+def generate_fake_projections(
+    n_projections: int = 1440,
+) -> np.ndarray:
+    # create the synthetic object
+    # use default shape: 128x128x128
+    shepp3d = tomopy.misc.phantom.shepp3d()
+    # create the projections (1440 -> 0.25 deg step)
+    omegas = np.linspace(0, np.pi * 2, n_projections)
+    radiograph_stack = tomopy.sim.project.project(shepp3d, omegas, emission=False)
+    return radiograph_stack
+
+
+def generate_fake_flatfield(
+    radiograph: np.ndarray,
+    intensity_average: int,
+    dynamic_range: int,
+) -> np.ndarray:
+    # calculate bound
+    low_bound = max(1_000, intensity_average - dynamic_range / 2)
+    high_bound = min(65_000, intensity_average + dynamic_range / 2)
+    # generate a flatfield
+    flat = np.random.randint(
+        low=low_bound,
+        high=high_bound,
+        size=radiograph.shape,
+    )
+    #
+    return flat
+
+
+def generate_flickering_projections(
+    projections_ideal: np.ndarray,
+) -> np.ndarray:
+    # make a fake fluctuating beam intensity profile
+    n_projections = projections_ideal.shape[0]
+    x = np.linspace(0, 0.5, int(n_projections / 2))
+    x = np.vstack((x, x)).flatten()
+    intensity = (-(x ** 2) + 1) * 50_000
+    dynamic_range = 20_000
+    # make flats
+    flats = np.array(
+        [generate_fake_flatfield(projections_ideal[0], intensity[i], dynamic_range) for i in range(n_projections)]
+    )
+    # make it flickering
+    projections = projections_ideal * flats
+    # pretend the projections has gone through the regular flatfield correction
+    flat_avg = np.mean(flats, axis=0)
+    projections = projections / flat_avg
+    return projections
+
+
+def test_correct_with_tomopy():
+    # get synthetic projections
+    projs_ideal = generate_fake_projections()
+    # generate the corresponding flickering projections
+    projs_flickering = generate_flickering_projections(projs_ideal)
+    # perform correction
+    projs_corrected = intensity_fluctuation_correction(projs_flickering)
+    # verify
+    # NOTE: after the correction, the air region within each sinogram should be
+    #       close to uniform, therefore should result in smaller variance when
+    #       compared with the ideal one.
+    diff_raw = projs_flickering - projs_ideal
+    diff_corrected = projs_corrected - projs_ideal
+    assert diff_corrected.var() < diff_raw.var()
+
+
+def test_correct_with_imars3d():
+    # NOTE:
+    #  The original imars3d method's logic is unclear, therefore cannot be verified
+    #  at the moment.
+    pass
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])


### PR DESCRIPTION
- Original Gitlab Story: [IMG156](https://code.ornl.gov/sns-hfir-scse/imaging/imaging/-/issues/156)

This PR introduces the following changes:

- Intensity fluctuation correction via tomopy.normalize_bg (when air region/pixel specified).
- Intensity fluctuation correction via skimage (when air region specified with negative value).
- corresponding unit tests.