### PR TITLE
[IMG178] update pre-commit to include more hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,24 +3,39 @@
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.0.0
+    rev: v4.3.0
     hooks:
       - id: trailing-whitespace
+        exclude: |
+          (?x)\.(cif|
+                 gsa|
+                 gpx|
+                 dat)$
       - id: check-docstring-first
       - id: check-json
       - id: check-added-large-files
+        args: [--maxkb=4096]
       - id: check-yaml
       - id: debug-statements
       - id: requirements-txt-fixer
       - id: check-merge-conflict
       - id: end-of-file-fixer
+        exclude: |
+          (?x)\.(gpx)$
       - id: sort-simple-yaml
   - repo: https://github.com/psf/black
-    rev: 20.8b1
+    rev: 22.3.0
     hooks:
       - id: black
         args: ['--line-length=119']
-  # - repo: https://github.com/PyCQA/flake8
-  #   rev: 3.9.0
-  #   hooks:
-  #   - id: flake8
+  - repo: https://github.com/PyCQA/flake8
+    rev: 4.0.1
+    hooks:
+    - id: flake8
+      exclude: |
+        (?x)^(
+                ^src/imars3d/.+ |
+                ^tests/legacy/.+ |
+                ^docs/conf.py |
+                ^builders/.+
+            )$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,11 +6,6 @@ repos:
     rev: v4.3.0
     hooks:
       - id: trailing-whitespace
-        exclude: |
-          (?x)\.(cif|
-                 gsa|
-                 gpx|
-                 dat)$
       - id: check-docstring-first
       - id: check-json
       - id: check-added-large-files
@@ -20,8 +15,6 @@ repos:
       - id: requirements-txt-fixer
       - id: check-merge-conflict
       - id: end-of-file-fixer
-        exclude: |
-          (?x)\.(gpx)$
       - id: sort-simple-yaml
   - repo: https://github.com/psf/black
     rev: 22.3.0

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -50,9 +50,9 @@ source_suffix = ".rst"
 master_doc = "index"
 
 # General information about the project.
-project = u"iMars3D"
-copyright = u"2015, iMars3D team"
-author = u"iMars3D team"
+project = "iMars3D"
+copyright = "2015, iMars3D team"
+author = "iMars3D team"
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -223,7 +223,7 @@ latex_elements = {
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-    (master_doc, "iMars3D.tex", u"iMars3D Documentation", u"iMars3D team", "manual"),
+    (master_doc, "iMars3D.tex", "iMars3D Documentation", "iMars3D team", "manual"),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of
@@ -251,7 +251,7 @@ latex_documents = [
 
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
-man_pages = [(master_doc, "imars3d", u"iMars3D Documentation", [author], 1)]
+man_pages = [(master_doc, "imars3d", "iMars3D Documentation", [author], 1)]
 
 # If true, show URL addresses after external links.
 # man_show_urls = False
@@ -266,7 +266,7 @@ texinfo_documents = [
     (
         master_doc,
         "iMars3D",
-        u"iMars3D Documentation",
+        "iMars3D Documentation",
         author,
         "iMars3D",
         "One line description of project.",

--- a/src/imars3d/tilt/direct.py
+++ b/src/imars3d/tilt/direct.py
@@ -42,7 +42,7 @@ def _argmin_tilt(tilts, img0, flipped_img180, shift, workdir=None):
         logfile = open(os.path.join(workdir, "log._argmin_tilt"), "wt")
     for tilt in tilts:
         diff = shift_tilt_diff(shift, tilt, img0, flipped_img180)
-        diff = np.sum(diff ** 2) / diff.size
+        diff = np.sum(diff**2) / diff.size
         if workdir:
             logfile.write("* tilt=%s, diff=%s\n" % (tilt, diff))
         diffs.append(diff)
@@ -76,7 +76,7 @@ def shift_diff(x, img1, img2):
 
 def shift_diff2(x, img1, img2):
     d = shift_diff(x, img1, img2)
-    return (d ** 2).sum() / d.size
+    return (d**2).sum() / d.size
 
 
 MAX_SHIFT = 400

--- a/tests/legacy/imars3d/tilt/explore/findrotation_bypeakshift.py
+++ b/tests/legacy/imars3d/tilt/explore/findrotation_bypeakshift.py
@@ -30,7 +30,7 @@ from scipy.optimize import curve_fit
 
 def gauss(x, *p):
     A, mu, sigma = p
-    return A * np.exp(-((x - mu) ** 2) / (2.0 * sigma ** 2))
+    return A * np.exp(-((x - mu) ** 2) / (2.0 * sigma**2))
 
 
 def poly2(x, *p):

--- a/tests/unit/filters/test_intensity_fluctuation_correction.py
+++ b/tests/unit/filters/test_intensity_fluctuation_correction.py
@@ -44,7 +44,7 @@ def generate_flickering_projections(
     n_projections = projections_ideal.shape[0]
     x = np.linspace(0, 0.5, int(n_projections / 2))
     x = np.vstack((x, x)).flatten()
-    intensity = (-(x ** 2) + 1) * 50_000
+    intensity = (-(x**2) + 1) * 50_000
     dynamic_range = 20_000
     # make flats
     flats = np.array(


### PR DESCRIPTION
- original Gitlab task: [IMG178](https://code.ornl.gov/sns-hfir-scse/imaging/imaging/-/issues/178)

This PR introduces the following changes:

- more hooks for pre-commit
- enable flake8 hook
- exclude version1, legacy tests, and 3rd party files from flake8 check