### PR TITLE
[IMG158] add rotation center finder imars3d v2

### DIFF
--- a/src/imars3dv2/filters/__init__.py
+++ b/src/imars3dv2/filters/__init__.py
@@ -1,0 +1,1 @@
+from .tilt import find_180_deg_pairs_idx

--- a/src/imars3dv2/filters/rotation.py
+++ b/src/imars3dv2/filters/rotation.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+import numpy as np
+import tomopy
+import concurrent.futures as cf
+import tomopy.util.mproc as mproc
+from tomopy.recon.rotation import find_center_pc
+from imars3dv2.filters.tilt import find_180_deg_pairs_idx
+
+
+def find_rotation_center(
+    arrays: np.ndarray,
+    angles: np.ndarray,
+    in_degrees: bool = True,
+    ncore: int = -1,
+) -> float:
+    """
+    Automatically find the rotation center from a given radiograph stack.
+
+    Parameters
+    ----------
+    @param arrays: 3D array of images, the first dimension is the rotation angle omega
+    @param angles: array of angles in degrees or radians, which must match the order of arrays
+    @param in_degrees: whether angles are in degrees or radians, default is True (degrees)
+    @param ncore: number of cores to use for parallel median filtering, default is -1, which means using all available cores.
+
+    Returns
+    -------
+    @return: rotation center in pixels
+    """
+    # sanity check input
+    if arrays.ndim != 3:
+        raise ValueError("arrays must be 3D (valid radiograph stack)")
+    # locate 180 degree pairs
+    idx_low, idx_hgh = find_180_deg_pairs_idx(angles, in_degrees=in_degrees)
+    # process
+    ncore = mproc.mp.cpu_count() if ncore == -1 else int(ncore)
+    with cf.ProcessPoolExecutor(ncore) as e:
+        # NOTE:
+        # we are using the default half pixel tolerance for find_center_pc
+        jobs = [
+            e.submit(
+                find_center_pc,
+                arrays[il],
+                arrays[lh],
+            )
+            for il, lh in zip(idx_low, idx_hgh)
+        ]
+    centers = np.array([job.result() for job in jobs])
+    return np.median(centers)

--- a/src/imars3dv2/filters/rotation.py
+++ b/src/imars3dv2/filters/rotation.py
@@ -5,7 +5,7 @@ import tomopy
 import concurrent.futures as cf
 import tomopy.util.mproc as mproc
 from tomopy.recon.rotation import find_center_pc
-from imars3dv2.filters.tilt import find_180_deg_pairs_idx
+from imars3dv2.filters import find_180_deg_pairs_idx
 
 
 def find_rotation_center(

--- a/tests/unit/filters/test_rotation.py
+++ b/tests/unit/filters/test_rotation.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+import numpy as np
+import pytest
+import tomopy
+from imars3dv2.filters.rotation import find_rotation_center
+
+
+def get_synthetic_stack(
+    center: float,
+    omegas: np.ndarray,
+) -> np.ndarray:
+    """
+    Generate synthetic radiograph stack with given rotation center and rotation angles.
+
+    Parameter
+    ---------
+    @param center:
+        Rotation center
+    @param omegas:
+        Rotation angles in radians
+
+    Return
+    ------
+    @return
+        Radiograph stack of synthetic shepp3d rotating around center at omegas locations.
+    """
+    # NOTE:
+    # the simulator has some rounding errors, and we need to push the input center a tiny bit
+    # off a round number to get the correct results
+    center = center + 1e-4 if center else center
+    shepp3d = tomopy.misc.phantom.shepp3d(size=129)
+    projs = tomopy.sim.project.project(
+        shepp3d,
+        omegas,
+        emission=False,
+        center=center,
+    )
+    return projs
+
+
+@pytest.mark.parametrize(
+    "center_ref",
+    [
+        70,
+        80.5,
+        100.2,
+        119.5,
+    ],
+)
+def test_find_rotation_center(center_ref):
+    # prepare synthetic data
+    omegas = np.linspace(0, np.pi * 2, 181)
+    projs = get_synthetic_stack(center_ref, omegas)
+    # calculate the rotation center
+    center_calc = find_rotation_center(projs, omegas)
+    # verify
+    # NOTE:
+    # answer within the same pixel should be sufficient for most cases
+    np.testing.assert_almost_equal(center_calc, center_ref)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])


### PR DESCRIPTION
- Original Gitlab Story: [IMG157](https://code.ornl.gov/sns-hfir-scse/imaging/imaging/-/issues/158)

This PR introduces a rotation center finder, which is a wrapper around `tomopy.recon.rotation.find_center_pc`.