### PR TITLE
[IMG113] enable unit test with code coverage

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,3 +1,0 @@
-[flake8]
-    ignore = E203, E266, E501, W503, F403, F401
-    max-line-length = 120

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -1,6 +1,10 @@
 name: unit-test
 
-on: [push, pull_request]
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches: [next, qa, main]
 
 jobs:
   linux:

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -1,0 +1,26 @@
+name: unit-test
+
+on: [push, pull_request]
+
+jobs:
+  linux:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash -l {0}
+    steps:
+    - uses: actions/checkout@v2
+    - uses: conda-incubator/setup-miniconda@v2
+      with:
+        auto-update-conda: true
+        mamba-version: "*"
+        environment-file: conda_environment.yml
+    - name: Install testing requirements
+      run: mamba env update --file conda_development.yml
+    - name: Install iMars3dv2
+      run: pip install -e .
+    - name: Unit test with code coverage
+      run: |
+        python -m pytest --cov --cov-report=xml --cov-report=term tests/unit
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v1

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Install testing requirements
       run: mamba env update --name test --file conda_development.yml
     - name: Install iMars3dv2 in editable mode
-      run: conda develop .
+      run: pip install -e .
     - name: Unit test with code coverage
       run: |
         python -m pytest --cov --cov-report=xml --cov-report=term tests/unit

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Install testing requirements
       run: mamba env update --name test --file conda_development.yml
     - name: Install iMars3dv2 in editable mode
-      run: pip install -e .
+      run: conda develop .
     - name: Unit test with code coverage
       run: |
         python -m pytest --cov --cov-report=xml --cov-report=term tests/unit

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -21,7 +21,7 @@ jobs:
         environment-file: conda_environment.yml
     - name: Install testing requirements
       run: mamba env update --name test --file conda_development.yml
-    - name: Install iMars3dv2
+    - name: Install iMars3dv2 in editable mode
       run: pip install -e .
     - name: Unit test with code coverage
       run: |

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -16,7 +16,7 @@ jobs:
         mamba-version: "*"
         environment-file: conda_environment.yml
     - name: Install testing requirements
-      run: mamba env update --file conda_development.yml
+      run: mamba env update --name test --file conda_development.yml
     - name: Install iMars3dv2
       run: pip install -e .
     - name: Unit test with code coverage

--- a/conda_development.yml
+++ b/conda_development.yml
@@ -4,6 +4,7 @@ channels:
   - defaults
 dependencies:
   - black
+  - conda-build
   - pytest
   - pytest-cov
   - pre-commit

--- a/conda_development.yml
+++ b/conda_development.yml
@@ -1,4 +1,4 @@
-name: imars3d-dev
+name: imars3d
 channels:
   - conda-forge
   - defaults

--- a/conda_development.yml
+++ b/conda_development.yml
@@ -1,0 +1,12 @@
+name: imars3d-dev
+channels:
+  - conda-forge
+  - defaults
+dependencies:
+  - black
+  - pytest
+  - pytest-cov
+  - pre-commit
+  - sphinx
+  - sphinx_rtd_theme
+  - pip

--- a/conda_environment.yml
+++ b/conda_environment.yml
@@ -3,21 +3,9 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - astropy=5.0.2=py310hde88566_0
-  - dxchange=0.1.7=pyhd8ed1ab_0
-  - ipywe=0.1.3a1=py310hff52083_3
-  - matplotlib=3.5.1=py310hff52083_0
-  - mpi4py=3.1.3=py310h853ac07_0
-  - mpich=4.0.1=h846660c_100
-  - numpy=1.22.3=py310h45f3432_0
-  - progressbar2=4.0.0=pyhd8ed1ab_0
-  - psutil=5.9.0=py310h6acc77f_0
-  - pytest=7.1.1=py310hff52083_0
-  - pyyaml=6.0=py310h6acc77f_3
-  - scikit-image=0.19.2=py310hb5077e9_0
-  - scipy=1.8.0=py310hea5193d_1
-  - sphinx=4.4.0=pyh6c4a22f_1
-  - toml=0.10.2=pyhd8ed1ab_0
-  - tomopy=1.11.0=py310h8d81d44_101
-  - yaml=0.2.5=h7f98852_2
+  - astropy
+  - tomopy
+  - dxchange
   - pooch
+  - sphinx
+  - pytest

--- a/conda_environment.yml
+++ b/conda_environment.yml
@@ -7,5 +7,3 @@ dependencies:
   - tomopy
   - dxchange
   - pooch
-  - sphinx
-  - pytest

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,0 @@
-[pytest]
-testpaths = tests
-python_files = *test*.py
-norecursedirs = .git tmp* _tmp* __pycache__ *dataset* *data_set*

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,15 +23,6 @@ package_dir=
     =src
 packages = find:
 python_requires = >= 3.7
-install_requires =
-    pyyaml
-    numpy
-    scipy
-    matplotlib
-    astropy
-    mpi4py
-    psutil
-    scikit-image
 
 [options.packages.find]
 where = src

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,3 +35,16 @@ tests = pytest
 
 [aliases]
 test = pytest
+
+[flake8]
+ignore = E203, E266, E501, W503, F403, F401
+max-line-length = 120
+
+[tool:pytest]
+testpaths = tests
+python_files = *test*.py
+norecursedirs = .git tmp* _tmp* __pycache__ *dataset* *data_set*
+
+[coverage:run]
+source = src/imars3dv2
+omit = */tests/*

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,6 +23,11 @@ package_dir=
     =src
 packages = find:
 python_requires = >= 3.7
+install_requires =
+    astropy
+    tomopy
+    dxchange
+    pooch
 
 [options.packages.find]
 where = src


### PR DESCRIPTION
- Original Gitlab enabler: [IMG113](https://code.ornl.gov/sns-hfir-scse/imaging/imaging/-/issues/113)

This PR introduces the following changes:

- update conda environment file
  - separate environment file into runtime and development
  - only specify the base dependencies
- consolidate configuration files into `setup.cfg`
- add new workflow that will
  - run the unit test for each push and pull request
  - generate code coverage report (only for iMars3dV2) and upload the report to Codecov 