### PR TITLE
Wrapper for tomopy recon

### DIFF
--- a/src/imars3dv2/filters/recon.py
+++ b/src/imars3dv2/filters/recon.py
@@ -4,7 +4,7 @@ from tomopy.recon.algorithm import recon as tomo_recon
 
 
 def recon(
-    sinogram: np.ndarray,
+    arrays: np.ndarray,
     theta: np.array,
     center: np.array = None,
     algorithm: str = "gridrec",
@@ -12,12 +12,12 @@ def recon(
     **kwargs
 ) -> np.ndarray:
     """
-    Perform reconstruction on a stack of sinograms
+    Perform reconstruction on a stack of tomographic data
 
     Parameters
     ----------
-    @param sinogram:
-        Input stack of sinograms
+    @param arrays:
+        Input stack of tomography data
     @param theta:
         Projection angles (in radians)
     @param center:
@@ -30,12 +30,12 @@ def recon(
     Return
     ------
     @return
-        Reconstructed sinograms
+        Reconstructed tomographic data
     """
 
-    if sinogram.ndim != 3:
-        raise ValueError("Expected input sinogram array to have 3 dimensions")
+    if arrays.ndim != 3:
+        raise ValueError("Expected input array to have 3 dimensions")
 
     # TODO: allow different backends besides tomopy
-    result = tomo_recon(sinogram, theta, center=center, algorithm=algorithm, filter_name=filter_name, **kwargs)
+    result = tomo_recon(arrays, theta, center=center, algorithm=algorithm, filter_name=filter_name, **kwargs)
     return result

--- a/src/imars3dv2/filters/recon.py
+++ b/src/imars3dv2/filters/recon.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+import numpy as np
+from tomopy.recon.algorithm import recon as tomo_recon
+
+
+def recon(
+    sinogram: np.ndarray,
+    theta: np.array,
+    center: np.array = None,
+    algorithm: str = "gridrec",
+    filter_name: str = "hann",
+    **kwargs
+) -> np.ndarray:
+    """
+    Perform reconstruction on a stack of sinograms
+
+    Parameters
+    ----------
+    @param sinogram:
+        Input stack of sinograms
+    @param theta:
+        Projection angles (in radians)
+    @param center:
+        Rotation center
+    @param algorithm:
+        Name of reconstruction algorithm
+    @param filter_name:
+        Name of filter used for reconstruction
+
+    Return
+    ------
+    @return
+        Reconstructed sinograms
+    """
+
+    if sinogram.ndim != 3:
+        raise ValueError("Expected input sinogram array to have 3 dimensions")
+
+    # TODO: allow different backends besides tomopy
+    result = tomo_recon(sinogram, theta, center=center, algorithm=algorithm, filter_name=filter_name, **kwargs)
+    return result

--- a/tests/unit/filters/test_recon.py
+++ b/tests/unit/filters/test_recon.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+import numpy as np
+import pytest
+import tomopy
+from imars3dv2.filters.recon import recon
+
+
+def test_recon():
+    # generate testing data for reconstruction
+    omegas = np.linspace(0, np.pi * 2, 181)
+    shepp3d = tomopy.misc.phantom.shepp3d(size=129)
+    projs = tomopy.sim.project.project(shepp3d, omegas, emission=True)
+
+    with pytest.raises(ValueError):
+        # check that input is 3-dimensional
+        recon(projs[0, :, :], omegas)
+
+    # run reconstruction
+    result = recon(projs, omegas)
+
+    # extract a region around the center of each slice to compare
+    center = int(result[64].shape[1] / 2)
+    result_slice = result[64, center - 30 : center + 30, center - 30 : center + 30]
+
+    center = int(shepp3d[64].shape[1] / 2)
+    shepp_slice = shepp3d[64, center - 30 : center + 30, center - 30 : center + 30]
+
+    # reconstructed image should roughly match original
+    assert np.linalg.norm(result_slice - shepp_slice) / result_slice.size < 1e-3
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])


### PR DESCRIPTION
Adds a simple wrapper function for calling `tomopy.recon`. Refer to Gitlab story [IMG160](https://code.ornl.gov/sns-hfir-scse/imaging/imaging/-/issues/160).