### PR TITLE
only report fail if the coverage drops below 60

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -57,3 +57,6 @@ omit =
         */tests/*
         src/imars3d/widgets_prototype/*
         src/imars3d/__init__.py
+
+[coverage:report]
+fail_under = 60


### PR DESCRIPTION
This PR introduces a small change that stops code coverage from report failure as long as the coverage is above 60%.