### PR TITLE
add yamllint to pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,3 +36,12 @@ repos:
                 ^docs/conf.py |
                 ^builders/.+
             )$
+  - repo: https://github.com/adrienverge/yamllint.git
+    rev: v1.28.0
+    hooks:
+    - id: yamllint
+    name: yamllint
+    description: This hook runs yamllint.
+    entry: yamllint
+    language: python
+    types: [file, yaml]

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,34 @@
+---
+
+yaml-files:
+  - '*.yaml'
+  - '*.yml'
+  - '.yamllint'
+
+rules:
+  braces: enable
+  brackets: enable
+  colons: enable
+  commas: enable
+  comments:
+    level: warning
+  comments-indentation:
+    level: warning
+  document-end: disable
+  document-start: disable
+  empty-lines: enable
+  empty-values: disable
+  float-values: disable
+  hyphens: enable
+  indentation:
+    level: warning
+    indent-sequences: consistent
+  key-duplicates: enable
+  key-ordering: disable
+  line-length: enable
+  new-line-at-end-of-file: enable
+  new-lines: enable
+  octal-values: disable
+  quoted-strings: disable
+  trailing-spaces: enable
+  truthy: disable

--- a/.yamllint
+++ b/.yamllint
@@ -5,6 +5,9 @@ yaml-files:
   - '*.yml'
   - '.yamllint'
 
+ignore: |
+  conda.recipe/meta.yaml
+
 rules:
   braces: enable
   brackets: enable
@@ -25,7 +28,9 @@ rules:
     indent-sequences: consistent
   key-duplicates: enable
   key-ordering: disable
-  line-length: enable
+  line-length:
+    max: 256
+    level: warning
   new-line-at-end-of-file: enable
   new-lines: enable
   octal-values: disable

--- a/conda_development.yml
+++ b/conda_development.yml
@@ -28,3 +28,4 @@ dependencies:
   - pip:
     - versioningit
     - check-wheel-contents
+    - yamllint


### PR DESCRIPTION
- no parent gitlab enabler

This PR adds yamllint as part of the pre-commit check, which automatically ensures that added yaml files are valid.
