### PR TITLE
[IMG282] UI for load data

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -21,6 +21,8 @@ jobs:
           environment-file: conda_environment.yml
       - name: Install testing requirements
         run: mamba env update --name test --file conda_development.yml
+      - name: Install ui test requirements
+        run: playwright install
       - name: Install iMars3d in editable mode
         run: pip install -e .
       - name: Unit test with code coverage

--- a/conda_development.yml
+++ b/conda_development.yml
@@ -30,3 +30,4 @@ dependencies:
     - versioningit
     - check-wheel-contents
     - yamllint
+    - pytest-playwright

--- a/src/imars3d/backend/io/config.py
+++ b/src/imars3d/backend/io/config.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+"""
+Configuration file handler for the imars3d.
+"""
+import json
+from pathlib import Path
+
+
+def save_config(
+    config_dict: dict,
+    filepath: str,
+):
+    # sanity check
+    filepath = Path(filepath)
+    if filepath.suffix not in (".json", ".JSON"):
+        raise ValueError("incorrect config file extension")
+
+    # make the directory if not exist
+    filepath.parent.mkdir(parents=True, exist_ok=True)
+
+    # now write to disk
+    with open(filepath, "w") as outfile:
+        json.dump(config_dict, outfile, indent=2, sort_keys=False)

--- a/src/imars3d/ui/stages/dataloading.py
+++ b/src/imars3d/ui/stages/dataloading.py
@@ -57,9 +57,10 @@ class DataLoader(param.Parameterized):
             },
             "outputs": ["ct", "ob", "dc", "rot_angles"],
         }
-        self.config_dict["steps"].append(load_step)
+        self.config_dict["tasks"].append(load_step)
+        self.param.trigger("config_dict")
 
-    @param.depends("config_dict")
+    @param.depends("config_dict", on_init=True)
     def file_selector(self):
         # use user home directory if invalid one found in config file
         prjdir = str(Path.home())
@@ -86,7 +87,7 @@ class DataLoader(param.Parameterized):
     def as_dict(self):
         return self.config_dict
 
-    @param.depends("config_dict")
+    @param.depends("config_dict", on_init=True)
     def json_editor(self):
         json_editor = pn.widgets.JSONEditor.from_param(
             self.param.config_dict,
@@ -106,9 +107,10 @@ class DataLoader(param.Parameterized):
         save_json_button = pn.widgets.Button.from_param(self.param.save_config_to_disk, name="Save Config")
         update_config_button = pn.widgets.Button.from_param(self.param.update_config_action, name="Update Config")
         buttons = pn.Row(update_config_button, save_json_button)
-        return pn.Column(
+        app = pn.Column(
             buttons,
             self.file_selector,
             self.json_editor,
             sizing_mode="stretch_width",
         )
+        return app

--- a/src/imars3d/ui/stages/dataloading.py
+++ b/src/imars3d/ui/stages/dataloading.py
@@ -19,7 +19,7 @@ class DataLoader(param.Parameterized):
             "name": "TBD",
             "workingdir": "TBD",
             "outputdir": "TBD",
-            "steps": [],
+            "tasks": [],
         },
         doc="Configuration dictionary",
     )
@@ -49,7 +49,7 @@ class DataLoader(param.Parameterized):
         # default values for max_workers (by not setting one here).
         load_step = {
             "name": "load",
-            "version": 1,  # where does this version come from?
+            "function": "imars3d.backend.io.data.load_data",
             "inputs": {
                 "ct_files": self.radiograph_folder.value,
                 "ob_files": self.openbeam.value,

--- a/src/imars3d/ui/stages/dataloading.py
+++ b/src/imars3d/ui/stages/dataloading.py
@@ -55,7 +55,7 @@ class DataLoader(param.Parameterized):
                 "ob_files": self.openbeam.value,
                 "dc_files": self.darkcurrent.value,
             },
-            "outputs": ["ct", "ob", "dc", "rot_angles"],
+            "outputs": [f"globals.{x}" if x in globals else x for x in ["ct", "ob", "dc", "rot_angles"]],
         }
         self.config_dict["tasks"].append(load_step)
         self.param.trigger("config_dict")

--- a/src/imars3d/ui/stages/dataloading.py
+++ b/src/imars3d/ui/stages/dataloading.py
@@ -55,7 +55,7 @@ class DataLoader(param.Parameterized):
                 "ob_files": self.openbeam.value,
                 "dc_files": self.darkcurrent.value,
             },
-            "outputs": [f"globals.{x}" if x in globals else x for x in ["ct", "ob", "dc", "rot_angles"]],
+            "outputs": ["ct", "ob", "dc", "rot_angles"],
         }
         self.config_dict["tasks"].append(load_step)
         self.param.trigger("config_dict")

--- a/src/imars3d/ui/stages/dataloading.py
+++ b/src/imars3d/ui/stages/dataloading.py
@@ -86,11 +86,8 @@ class DataLoader(param.Parameterized):
     def as_dict(self):
         return self.config_dict
 
-    def panel(self):
-        save_json_button = pn.widgets.Button.from_param(self.param.save_config_to_disk, name="Save Config")
-        update_config_button = pn.widgets.Button.from_param(self.param.update_config_action, name="Update Config")
-        buttons = pn.Row(update_config_button, save_json_button)
-        #
+    @param.depends("config_dict")
+    def json_editor(self):
         json_editor = pn.widgets.JSONEditor.from_param(
             self.param.config_dict,
             mode="view",
@@ -103,9 +100,15 @@ class DataLoader(param.Parameterized):
             sizing_mode="stretch_width",
             collapsed=True,
         )
+        return config_viewer
+
+    def panel(self):
+        save_json_button = pn.widgets.Button.from_param(self.param.save_config_to_disk, name="Save Config")
+        update_config_button = pn.widgets.Button.from_param(self.param.update_config_action, name="Update Config")
+        buttons = pn.Row(update_config_button, save_json_button)
         return pn.Column(
             buttons,
             self.file_selector,
-            config_viewer,
+            self.json_editor,
             sizing_mode="stretch_width",
         )

--- a/src/imars3d/ui/stages/metadata.py
+++ b/src/imars3d/ui/stages/metadata.py
@@ -98,7 +98,7 @@ class MetaData(param.Parameterized):
         return self.config_dict
 
     def summary_pane(self):
-        return pn.pane.Markdown(
+        return pn.panel(
             f"""
             # Summary for reconstruction: {self.recn_name}
             ----------------------------------------------

--- a/src/imars3d/ui/stages/metadata.py
+++ b/src/imars3d/ui/stages/metadata.py
@@ -118,6 +118,22 @@ class MetaData(param.Parameterized):
             sizing_mode="stretch_width",
         )
 
+    @param.depends("config_dict")
+    def json_editor(self):
+        json_editor = pn.widgets.JSONEditor.from_param(
+            self.param.config_dict,
+            mode="view",
+            menu=False,
+            sizing_mode="stretch_width",
+        )
+        config_viewer = pn.Card(
+            json_editor,
+            title="CONFIG Viewer",
+            sizing_mode="stretch_width",
+            collapsed=True,
+        )
+        return config_viewer
+
     @param.depends(
         "instrument",
         "ipts_num",
@@ -133,12 +149,6 @@ class MetaData(param.Parameterized):
         self.config_dict["workingdir"] = self.temp_root
         self.config_dict["outputdir"] = self.recn_root
 
-    @param.depends(
-        "instrument",
-        "ipts_num",
-        "facility",
-        "config_dict",
-    )
     def panel(self, width=250):
         inst_input = pn.widgets.Select.from_param(
             self.param.instrument,
@@ -172,22 +182,10 @@ class MetaData(param.Parameterized):
             cntl_pn,
             self.summary_pane,
         )
-        json_editor = pn.widgets.JSONEditor.from_param(
-            self.param.config_dict,
-            mode="view",
-            menu=False,
-            sizing_mode="stretch_width",
-        )
-        config_viewer = pn.Card(
-            json_editor,
-            title="CONFIG Viewer",
-            sizing_mode="stretch_width",
-            collapsed=True,
-        )
         #
         app = pn.Column(
             interactive_app,
-            config_viewer,
+            self.json_editor,
             sizing_mode="stretch_width",
         )
         return app

--- a/src/imars3d/ui/stages/metadata.py
+++ b/src/imars3d/ui/stages/metadata.py
@@ -1,13 +1,29 @@
 #!/usr/bin/env python3
-
+"""
+First stage to generate interactive reconstruction
+"""
 import param
 import panel as pn
 from pathlib import Path
+from imars3d.backend.io.config import save_config
 
 
 class MetaData(param.Parameterized):
-    # facility param required to locate the data on
-    # analysis mounts
+    # configuration to carry into the next stage
+    config_dict = param.Dict(
+        default={
+            "facility": "TBD",
+            "instrument": "TBD",
+            "ipts": 0,
+            "projectdir": "TBD",
+            "name": "TBD",
+            "workingdir": "TBD",
+            "outputdir": "TBD",
+            "steps": [],
+        } ,
+        doc="Configuration dictionary",
+    )
+    # basic input
     instrument = param.Selector(
         default="CG1D",
         objects=["CG1D", "SNAP", "VENUS", "CUPID"],
@@ -20,14 +36,12 @@ class MetaData(param.Parameterized):
         doc="IPTS number",
     )
     # derived project root
-    # NOTE: the IPTS-x sub-folder structure is not consistent among
-    #       different experiments (historical issues?), so we should
-    #       only specify the root, and let users decide where the
-    #       input data should be.
+    # NOTE: the IPTS-x sub-folder structure is not consistent among different experiments,
+    #       so we should only specify the root, and let users decide where the input data should be.
     # NOTE: basic dir structure
     #       /FACILITY/INSTRUMENT/IPTS-xxxx/
     #       - raw
-    #         |- strucutre unstable, but should always have open-beam, dark current(field), and input ct
+    #         |- strucutre unstable, but should always have open-beam, dark current, and input ct
     #       - shared
     #         |- processed_data
     #            |- where reconstruction results sits in each own folder
@@ -49,11 +63,13 @@ class MetaData(param.Parameterized):
         default=Path.home() / Path("tmp"),
         doc="intermedia results save location",
     )
-    #
-    # NOTE: recon name will also be used to save intermedia results as well for consistency
-    # - intermedia results: temp_root/recon_name/stage_name/data+config
-    # - final recon: recn_root/myreon/data+config
     recn_name = param.String(default="myrecon", doc="reconstruction results folder name")
+    save_config_to_disk = param.Action(lambda x: x.param.trigger("save_config_to_disk"))
+    
+    @param.depends("save_config_to_disk", watch=True)
+    def save_config_file(self):
+        config_filename = str(Path(self.recn_root) / self.recn_name / f"{self.recn_name}.json")
+        save_config(self.config_dict, config_filename)
 
     @param.depends("instrument", watch=True)
     def _update_facility(self):
@@ -76,18 +92,10 @@ class MetaData(param.Parameterized):
         self.recn_root = f"{self.proj_root}/shared/processed_data"
 
     @param.output(
-        ("data_root", param.Path),
-        ("recn_root", param.Path),
-        ("temp_root", param.Path),
-        ("recn_name", param.String),
+        ("config_dict", param.Dict),
     )
-    def metadata(self):
-        return (
-            self.data_root,
-            self.recn_root,
-            self.temp_root,
-            self.recn_name,
-        )
+    def as_dict(self):
+        return self.config_dict
 
     def summary_pane(self):
         return pn.pane.Markdown(
@@ -102,12 +110,34 @@ class MetaData(param.Parameterized):
             | Raw data dir | `{self.data_root}` |
             | Results dir | `{Path(self.recn_root) / Path(self.recn_name)}` |
             | Checkpoint(s) dir | `{Path(self.temp_root) / Path(self.recn_name)}` |
+            | Configuration | `{Path(self.temp_root) / Path(self.recn_name) / f"{Path(self.recn_name)}.json"}` |
 
             > If the information above is correct, proceed to next step.
             """,
             sizing_mode="stretch_width",
         )
+    
+    @param.depends(
+        "instrument",
+        "ipts_num",
+        "facility",
+        watch=True,
+    )
+    def _update_config(self):
+        self.config_dict["instrument"] = self.instrument
+        self.config_dict["ipts"] = self.ipts_num
+        self.config_dict["facility"] = self.facility
+        self.config_dict["projectdir"] = self.proj_root
+        self.config_dict["name"] = self.recn_name
+        self.config_dict["workingdir"] = self.temp_root
+        self.config_dict["outputdir"] = self.recn_root
 
+    @param.depends(
+        "instrument",
+        "ipts_num",
+        "facility",
+        "config_dict",
+    )
     def panel(self, width=250):
         inst_input = pn.widgets.Select.from_param(
             self.param.instrument,
@@ -127,15 +157,36 @@ class MetaData(param.Parameterized):
         recnname_input = pn.widgets.TextInput.from_param(
             self.param.recn_name, name="Reconstrution name", placeholder="Enter a name for your reconstruction..."
         )
+        save_json_button = pn.widgets.Button.from_param(self.param.save_config_to_disk, name="Save Config")
         cntl_pn = pn.Column(
             inst_input,
             ipts_input,
             projroot_input,
             recnname_input,
+            save_json_button,
             width=width,
         )
         #
-        return pn.Row(
+        interactive_app = pn.Row(
             cntl_pn,
             self.summary_pane,
         )
+        json_editor = pn.widgets.JSONEditor.from_param(
+            self.param.config_dict,
+            mode="view",
+            menu=False,
+            sizing_mode="stretch_width",
+        )
+        config_viewer = pn.Card(
+            json_editor,
+            title="CONFIG Viewer",
+            sizing_mode="stretch_width",
+            collapsed=True,
+        )
+        #
+        app = pn.Column(
+            interactive_app,
+            config_viewer,
+            sizing_mode="stretch_width",
+        )
+        return app

--- a/src/imars3d/ui/stages/metadata.py
+++ b/src/imars3d/ui/stages/metadata.py
@@ -118,7 +118,7 @@ class MetaData(param.Parameterized):
             sizing_mode="stretch_width",
         )
 
-    @param.depends("config_dict")
+    @param.depends("config_dict", on_init=True)
     def json_editor(self):
         json_editor = pn.widgets.JSONEditor.from_param(
             self.param.config_dict,
@@ -148,6 +148,7 @@ class MetaData(param.Parameterized):
         self.config_dict["name"] = self.recn_name
         self.config_dict["workingdir"] = self.temp_root
         self.config_dict["outputdir"] = self.recn_root
+        self.param.trigger("config_dict")
 
     def panel(self, width=250):
         inst_input = pn.widgets.Select.from_param(

--- a/src/imars3d/ui/stages/metadata.py
+++ b/src/imars3d/ui/stages/metadata.py
@@ -20,7 +20,7 @@ class MetaData(param.Parameterized):
             "workingdir": "TBD",
             "outputdir": "TBD",
             "steps": [],
-        } ,
+        },
         doc="Configuration dictionary",
     )
     # basic input
@@ -65,7 +65,7 @@ class MetaData(param.Parameterized):
     )
     recn_name = param.String(default="myrecon", doc="reconstruction results folder name")
     save_config_to_disk = param.Action(lambda x: x.param.trigger("save_config_to_disk"))
-    
+
     @param.depends("save_config_to_disk", watch=True)
     def save_config_file(self):
         config_filename = str(Path(self.recn_root) / self.recn_name / f"{self.recn_name}.json")
@@ -116,7 +116,7 @@ class MetaData(param.Parameterized):
             """,
             sizing_mode="stretch_width",
         )
-    
+
     @param.depends(
         "instrument",
         "ipts_num",

--- a/src/imars3d/ui/stages/metadata.py
+++ b/src/imars3d/ui/stages/metadata.py
@@ -68,7 +68,8 @@ class MetaData(param.Parameterized):
 
     @param.depends("save_config_to_disk", watch=True)
     def save_config_file(self):
-        config_filename = str(Path(self.recn_root) / self.recn_name / f"{self.recn_name}.json")
+        wkdir = Path(self.config_dict["outputdir"])
+        config_filename = str(wkdir / f"{self.config_dict['name']}.json")
         save_config(self.config_dict, config_filename)
 
     @param.depends("instrument", watch=True)

--- a/src/imars3d/ui/stages/metadata.py
+++ b/src/imars3d/ui/stages/metadata.py
@@ -19,7 +19,7 @@ class MetaData(param.Parameterized):
             "name": "TBD",
             "workingdir": "TBD",
             "outputdir": "TBD",
-            "steps": [],
+            "tasks": [],
         },
         doc="Configuration dictionary",
     )
@@ -61,7 +61,7 @@ class MetaData(param.Parameterized):
     )
     temp_root = param.Path(
         default=Path.home() / Path("tmp"),
-        doc="intermedia results save location",
+        doc="intermediate results save location",
     )
     recn_name = param.String(default="myrecon", doc="reconstruction results folder name")
     save_config_to_disk = param.Action(lambda x: x.param.trigger("save_config_to_disk"))

--- a/tests/unit/backend/io/test_config.py
+++ b/tests/unit/backend/io/test_config.py
@@ -1,1 +1,25 @@
 #!/usr/bin/env python3
+from dataclasses import field
+import pytest
+import os
+import json
+from imars3d.backend.io.config import save_config
+
+
+def test_save_config():
+    config = {"test": 1}
+    # error_1: incorrect file extension
+    with pytest.raises(ValueError):
+        save_config(config, "test.test")
+    # case: save correctly
+    filepath = "test.json"
+    save_config(config, filepath)
+    with open(filepath, "r") as infile:
+        config_readin = json.load(infile)
+    assert config == config_readin
+    # cleanup
+    os.remove(filepath)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])

--- a/tests/unit/ui/stages/test_dataloading.py
+++ b/tests/unit/ui/stages/test_dataloading.py
@@ -26,7 +26,7 @@ def ref_config():
         "name": "unittest",
         "workingdir": "/tmp",
         "outputdir": "/tmp",
-        "steps": [],
+        "tasks": [],
     }
     # cleanup
     shutil.rmtree("/tmp/unittest.json", ignore_errors=True)
@@ -58,7 +58,7 @@ def test_loaddata_page(page: Page, port: int, ref_config: dict) -> None:
     page.locator("text=Save Config").click()
     time.sleep(1)
 
-    assert dataloader.config_dict["steps"][0]["inputs"]["ct_files"][0] == "/tmp/unittest.json"
+    assert dataloader.config_dict["tasks"][0]["inputs"]["ct_files"][0] == "/tmp/unittest.json"
 
 
 if __name__ == "__main__":

--- a/tests/unit/ui/stages/test_dataloading.py
+++ b/tests/unit/ui/stages/test_dataloading.py
@@ -1,1 +1,65 @@
 #!/usr/bin/env python3
+from cgi import test
+import pytest
+import shutil
+import time
+import panel as pn
+from panel.io.server import serve
+from playwright.sync_api import Page
+from imars3d.ui.stages.dataloading import DataLoader
+
+pn.extension("jsoneditor")
+
+
+@pytest.fixture(scope="module")
+def port():
+    return 1957
+
+
+@pytest.fixture(scope="module")
+def ref_config():
+    yield {
+        "facility": "HFIR",
+        "instrument": "CG1D",
+        "ipts": 11111,
+        "projectdir": "/tmp",
+        "name": "unittest",
+        "workingdir": "/tmp",
+        "outputdir": "/tmp",
+        "steps": [],
+    }
+    # cleanup
+    shutil.rmtree("/tmp/unittest.json", ignore_errors=True)
+
+
+def test_loaddata_page(page: Page, port: int, ref_config: dict) -> None:
+    # Serve the app
+    dataloader = DataLoader(config_dict=ref_config)
+    app = pn.panel(dataloader.panel)
+    serve(app, port=port, show=False, thread=True)
+
+    # Go to http://localhost:1957/
+    page.goto("http://localhost:1957/")
+    # Click text=Save Config so that we have something to load
+    page.locator("text=Save Config").click()
+    time.sleep(1)
+    # Click [placeholder="Filter available options"] >> nth=0
+    page.locator('[placeholder="Filter available options"]').first.click()
+    # Fill [placeholder="Filter available options"] >> nth=0
+    page.locator('[placeholder="Filter available options"]').first.fill("unittest.json")
+    # Press Enter
+    page.locator('[placeholder="Filter available options"]').first.press("Enter")
+    # Click text=/.*\>\>.*/ >> nth=0
+    page.locator("text=/.*\\>\\>.*/").first.click()
+    # Click text=Update Config
+    page.locator("text=Update Config").click()
+    time.sleep(1)
+    # Click text=Save Config so that we have something to load
+    page.locator("text=Save Config").click()
+    time.sleep(1)
+
+    assert dataloader.config_dict["steps"][0]["inputs"]["ct_files"][0] == "/tmp/unittest.json"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])

--- a/tests/unit/ui/stages/test_metadata.py
+++ b/tests/unit/ui/stages/test_metadata.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 import pytest
 import shutil
+import time
 import panel as pn
 from pathlib import Path
 from panel.io.server import serve
@@ -73,20 +74,12 @@ def test_example(page: Page, port:int, test_dir: str) -> None:
     # Press Enter
     page.locator("input[type=\"text\"]").first.press("Enter")
 
-    # Click text=►CONFIG Viewer
-    page.locator("text=►CONFIG Viewer").click()
-
-    # Click .jsoneditor-expand-all
-    page.locator(".jsoneditor-expand-all").click()
-
-    # Click .jsoneditor-collapse-all
-    page.locator(".jsoneditor-collapse-all").click()
-
-    # Click text=▼CONFIG Viewer
-    page.locator("text=▼CONFIG Viewer").click()
+    # Click th:has-text("Info"), force trigger update
+    page.locator("th:has-text(\"Info\")").click()
 
     # Click text=Save Config
     page.locator("text=Save Config").click()
+    time.sleep(1)
 
     # verify that the config file is created
     config_file = Path(test_dir) / Path("shared/processed_data/unittest/unittest.json")

--- a/tests/unit/ui/stages/test_metadata.py
+++ b/tests/unit/ui/stages/test_metadata.py
@@ -32,7 +32,7 @@ def test_dir():
     shutil.rmtree(tmp_dir)
 
 
-def test_example(page: Page, port:int, test_dir: str) -> None:
+def test_example(page: Page, port: int, test_dir: str) -> None:
     # Serve the app
     app = pn.panel(MetaData().panel)
     serve(app, port=port, show=False, thread=True)
@@ -48,34 +48,34 @@ def test_example(page: Page, port:int, test_dir: str) -> None:
     page.locator("select").select_option("CG1D")
 
     # Click [placeholder="Enter non-standard project root manually here\.\.\."]
-    page.locator("[placeholder=\"Enter non-standard project root manually here\\.\\.\\.\"]").click()
+    page.locator('[placeholder="Enter non-standard project root manually here\\.\\.\\."]').click()
 
     # Fill [placeholder="Enter non-standard project root manually here\.\.\."]
-    page.locator("[placeholder=\"Enter non-standard project root manually here\\.\\.\\.\"]").fill("/home")
+    page.locator('[placeholder="Enter non-standard project root manually here\\.\\.\\."]').fill("/home")
 
     # Press Enter
-    page.locator("[placeholder=\"Enter non-standard project root manually here\\.\\.\\.\"]").press("Enter")
+    page.locator('[placeholder="Enter non-standard project root manually here\\.\\.\\."]').press("Enter")
 
     # Click [placeholder="Enter a name for your reconstruction\.\.\."]
-    page.locator("[placeholder=\"Enter a name for your reconstruction\\.\\.\\.\"]").click()
+    page.locator('[placeholder="Enter a name for your reconstruction\\.\\.\\."]').click()
 
     # Fill [placeholder="Enter a name for your reconstruction\.\.\."]
-    page.locator("[placeholder=\"Enter a name for your reconstruction\\.\\.\\.\"]").fill("unittest")
+    page.locator('[placeholder="Enter a name for your reconstruction\\.\\.\\."]').fill("unittest")
 
     # Press Enter
-    page.locator("[placeholder=\"Enter a name for your reconstruction\\.\\.\\.\"]").press("Enter")
+    page.locator('[placeholder="Enter a name for your reconstruction\\.\\.\\."]').press("Enter")
 
     # Click input[type="text"] >> nth=0
-    page.locator("input[type=\"text\"]").first.click()
+    page.locator('input[type="text"]').first.click()
 
     # Fill input[type="text"] >> nth=0
-    page.locator("input[type=\"text\"]").first.fill("11111")
+    page.locator('input[type="text"]').first.fill("11111")
 
     # Press Enter
-    page.locator("input[type=\"text\"]").first.press("Enter")
+    page.locator('input[type="text"]').first.press("Enter")
 
     # Click th:has-text("Info"), force trigger update
-    page.locator("th:has-text(\"Info\")").click()
+    page.locator('th:has-text("Info")').click()
 
     # Click text=Save Config
     page.locator("text=Save Config").click()

--- a/tests/unit/ui/stages/test_metadata.py
+++ b/tests/unit/ui/stages/test_metadata.py
@@ -1,18 +1,97 @@
 #!/usr/bin/env python3
+import pytest
+import shutil
 import panel as pn
+from pathlib import Path
 from panel.io.server import serve
 from playwright.sync_api import Page, expect
 from imars3d.ui.stages.metadata import MetaData
 
-
 pn.extension("jsoneditor")
 
-def test_metadata():
-    # start the app
+
+@pytest.fixture(scope="module")
+def port():
+    return 1960
+
+
+@pytest.fixture(scope="module")
+def test_dir():
+    # make tmp dir
+    tmp_dir = Path.home() / Path("tmp/HFIR/CG1D/IPTS-11111")
+    tmp_dir.mkdir(parents=True, exist_ok=True)
+    # shared/processed_data
+    shared_dir = tmp_dir / Path("shared/processed_data")
+    shared_dir.mkdir(parents=True, exist_ok=True)
+    # raw
+    raw_dir = tmp_dir / Path("raw")
+    raw_dir.mkdir(parents=True, exist_ok=True)
+    yield str(tmp_dir)
+    # cleanup
+    shutil.rmtree(tmp_dir)
+
+
+def test_example(page: Page, port:int, test_dir: str) -> None:
+    # Serve the app
     app = pn.panel(MetaData().panel)
-    serve(app, port=1960, threaded=True, show=True)
-    pass
+    serve(app, port=port, show=False, thread=True)
+
+    # --- Test with Playwright ---
+    # Go to http://localhost:port/
+    page.goto(f"http://localhost:{port}/")
+
+    # Select SNAP
+    page.locator("select").select_option("SNAP")
+
+    # Select CG1D
+    page.locator("select").select_option("CG1D")
+
+    # Click [placeholder="Enter non-standard project root manually here\.\.\."]
+    page.locator("[placeholder=\"Enter non-standard project root manually here\\.\\.\\.\"]").click()
+
+    # Fill [placeholder="Enter non-standard project root manually here\.\.\."]
+    page.locator("[placeholder=\"Enter non-standard project root manually here\\.\\.\\.\"]").fill("/home")
+
+    # Press Enter
+    page.locator("[placeholder=\"Enter non-standard project root manually here\\.\\.\\.\"]").press("Enter")
+
+    # Click [placeholder="Enter a name for your reconstruction\.\.\."]
+    page.locator("[placeholder=\"Enter a name for your reconstruction\\.\\.\\.\"]").click()
+
+    # Fill [placeholder="Enter a name for your reconstruction\.\.\."]
+    page.locator("[placeholder=\"Enter a name for your reconstruction\\.\\.\\.\"]").fill("unittest")
+
+    # Press Enter
+    page.locator("[placeholder=\"Enter a name for your reconstruction\\.\\.\\.\"]").press("Enter")
+
+    # Click input[type="text"] >> nth=0
+    page.locator("input[type=\"text\"]").first.click()
+
+    # Fill input[type="text"] >> nth=0
+    page.locator("input[type=\"text\"]").first.fill("11111")
+
+    # Press Enter
+    page.locator("input[type=\"text\"]").first.press("Enter")
+
+    # Click text=►CONFIG Viewer
+    page.locator("text=►CONFIG Viewer").click()
+
+    # Click .jsoneditor-expand-all
+    page.locator(".jsoneditor-expand-all").click()
+
+    # Click .jsoneditor-collapse-all
+    page.locator(".jsoneditor-collapse-all").click()
+
+    # Click text=▼CONFIG Viewer
+    page.locator("text=▼CONFIG Viewer").click()
+
+    # Click text=Save Config
+    page.locator("text=Save Config").click()
+
+    # verify that the config file is created
+    config_file = Path(test_dir) / Path("shared/processed_data/unittest/unittest.json")
+    assert config_file.exists()
 
 
 if __name__ == "__main__":
-    test_metadata()
+    pytest.main([__file__])

--- a/tests/unit/ui/stages/test_metadata.py
+++ b/tests/unit/ui/stages/test_metadata.py
@@ -5,7 +5,7 @@ import time
 import panel as pn
 from pathlib import Path
 from panel.io.server import serve
-from playwright.sync_api import Page, expect
+from playwright.sync_api import Page
 from imars3d.ui.stages.metadata import MetaData
 
 pn.extension("jsoneditor")
@@ -32,7 +32,7 @@ def test_dir():
     shutil.rmtree(tmp_dir)
 
 
-def test_example(page: Page, port: int, test_dir: str) -> None:
+def test_metadata_page(page: Page, port: int, test_dir: str) -> None:
     # Serve the app
     app = pn.panel(MetaData().panel)
     serve(app, port=port, show=False, thread=True)
@@ -82,7 +82,7 @@ def test_example(page: Page, port: int, test_dir: str) -> None:
     time.sleep(1)
 
     # verify that the config file is created
-    config_file = Path(test_dir) / Path("shared/processed_data/unittest/unittest.json")
+    config_file = Path(test_dir) / Path("shared/processed_data/unittest.json")
     assert config_file.exists()
 
 

--- a/tests/unit/ui/stages/test_metadata.py
+++ b/tests/unit/ui/stages/test_metadata.py
@@ -1,1 +1,18 @@
 #!/usr/bin/env python3
+import panel as pn
+from panel.io.server import serve
+from playwright.sync_api import Page, expect
+from imars3d.ui.stages.metadata import MetaData
+
+
+pn.extension("jsoneditor")
+
+def test_metadata():
+    # start the app
+    app = pn.panel(MetaData().panel)
+    serve(app, port=1960, threaded=True, show=True)
+    pass
+
+
+if __name__ == "__main__":
+    test_metadata()


### PR DESCRIPTION
- Original Gitlab story: [IMG282](https://code.ornl.gov/sns-hfir-scse/imaging/imaging/-/issues/282)

This PR introduces the following changes:

- updated `MetaData` and `DataLoading` class that serialize itself into json for output
- utility function to handle json input
- corresponding ui unit test based off `PlayWright`
  - please following [this documentation](https://imars3d.readthedocs.io/en/latest/developer/ui_test.html) to perform ui tests locally.

To test the two stages, copy the following code in a cell

```python
import panel as pn
from imars3d.ui.stages.metadata import MetaData
from imars3d.ui.stages.dataloading import DataLoader

pn.extension("jsoneditor")

# build the pipeline
wizard = pn.pipeline.Pipeline(
    stages=[
        ("Metadata", MetaData),
        ("Load Data", DataLoader),
    ],
    debug=True,
)
# NOTE: we have to disable the axes linking as it will try to link with
# the "ct" viewers in the pipeline.
wizard.network.linked_axes = False
wizard.servable()
```
and you should be able to see the app in the cell

![Screenshot from 2022-09-28 13-50-25](https://user-images.githubusercontent.com/5064852/192853987-d5d43b71-7309-40aa-8eff-8b6728fa117d.jpg)

Alternatively, you can use this script at the root of the repo with `panel serve test.py` to view the two stages as a web app.

```python
#!/usr/bin/env python3

import panel as pn
from imars3d.ui.stages.metadata import MetaData
from imars3d.ui.stages.dataloading import DataLoader

pn.extension("jsoneditor")

# build the pipeline
wizard = pn.pipeline.Pipeline(
    stages=[
        ("Metadata", MetaData),
        ("Load Data", DataLoader),
    ],
    debug=True,
)
# NOTE: we have to disable the axes linking as it will try to link with
# the "ct" viewers in the pipeline.
wizard.network.linked_axes = False

# setup via template
pn.template.FastListTemplate(
    site="iMars3D demo",
    title="Neutron Image Reconstruction",
    logo="HFIR_SNS_logo.png",
    header_background="#00A170",
    main=wizard,
    # theme="dark",
    theme_toggle=False,
).servable()
```

Known issue:
~~The JSONEditor widget from `panel` does not auto refresh when its underlying dictionary is updated.~~
Update: the issue is resolved by adding a manual trigger after dict update to force a redraw of the JSONEditor.
