### PR TITLE
[IMG282] new MetaData class to help identify files from same scan

### DIFF
--- a/src/imars3d/backend/io/metadata.py
+++ b/src/imars3d/backend/io/metadata.py
@@ -66,7 +66,7 @@ class MetaData(param.Parameterized):
             if self.datatype in ("darkcurrent", "dc"):
                 self.metadata_index = [65026, 65027]
         elif self.suffix.lower() in (".fits", ".fit"):
-            raise NotImplementedError
+            raise ValueError(f'Suffix="{self.suffix}" is not currently supported')
 
     @param.depends("filename", "metadata_index", watch=True, on_init=True)
     def _update_metadata(self):

--- a/src/imars3d/backend/io/metadata.py
+++ b/src/imars3d/backend/io/metadata.py
@@ -86,7 +86,7 @@ class MetaData(param.Parameterized):
             me = self.metadata[k]
             te = other.metadata[k]
             if isinstance(me, str):
-                is_match = (me == te) and is_match
+                is_match = (me == te)
             elif isinstance(me, float):
                 is_match = (np.isclose(me, te, rtol=self.relative_tolerance)) and is_match
             # break early if is_match if false

--- a/src/imars3d/backend/io/metadata.py
+++ b/src/imars3d/backend/io/metadata.py
@@ -86,7 +86,7 @@ class MetaData(param.Parameterized):
             me = self.metadata[k]
             te = other.metadata[k]
             if isinstance(me, str):
-                is_match = (me == te)
+                is_match = me == te
             elif isinstance(me, float):
                 is_match = (np.isclose(me, te, rtol=self.relative_tolerance)) and is_match
             # break early if is_match if false

--- a/src/imars3d/backend/io/metadata.py
+++ b/src/imars3d/backend/io/metadata.py
@@ -88,7 +88,7 @@ class MetaData(param.Parameterized):
             if isinstance(me, str):
                 is_match = me == te
             elif isinstance(me, float):
-                is_match = (np.isclose(me, te, rtol=self.relative_tolerance))
+                is_match = np.isclose(me, te, rtol=self.relative_tolerance)
             # break early if is_match if false
             if not is_match:
                 break

--- a/src/imars3d/backend/io/metadata.py
+++ b/src/imars3d/backend/io/metadata.py
@@ -88,7 +88,7 @@ class MetaData(param.Parameterized):
             if isinstance(me, str):
                 is_match = me == te
             elif isinstance(me, float):
-                is_match = (np.isclose(me, te, rtol=self.relative_tolerance)) and is_match
+                is_match = (np.isclose(me, te, rtol=self.relative_tolerance))
             # break early if is_match if false
             if not is_match:
                 break

--- a/src/imars3d/backend/io/metadata.py
+++ b/src/imars3d/backend/io/metadata.py
@@ -10,7 +10,6 @@ from pathlib import Path
 
 # setup module level logger
 logger = param.get_logger(__name__)
-logger.name = __name__
 
 
 class MetaData(param.Parameterized):
@@ -66,6 +65,7 @@ class MetaData(param.Parameterized):
             if self.datatype in ("darkcurrent", "dc"):
                 self.metadata_index = [65026, 65027]
         elif self.suffix.lower() in (".fits", ".fit"):
+            logger.error("FITS file is not supported yet.")
             raise ValueError(f'Suffix="{self.suffix}" is not currently supported')
 
     @param.depends("filename", "metadata_index", watch=True, on_init=True)
@@ -76,8 +76,6 @@ class MetaData(param.Parameterized):
             raise NotImplementedError
 
     def __eq__(self, other):
-        if not isinstance(other, MetaData):
-            raise NotImplementedError
         # find the most common keys
         common_keys = [k for k in self.metadata.keys() if k in other.metadata.keys()]
         # check all entries

--- a/src/imars3d/backend/io/metadata.py
+++ b/src/imars3d/backend/io/metadata.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""
+Metadata class for IMars3D
+"""
+import numpy as np
+import param
+import tifffile
+from pathlib import Path
+
+
+# setup module level logger
+logger = param.get_logger(__name__)
+logger.name = __name__
+
+
+class MetaData(param.Parameterized):
+    """
+    Metadata extracted from given file
+    """
+
+    filename = param.Filename(doc="full path to the file.")
+    datatype = param.Selector(
+        default="ct",
+        objects=[
+            "radiograph",
+            "ct",
+            "openbeam",
+            "ob",
+            "darkcurrent",
+            "dc",
+        ],
+        doc="data type [ct|ob|dc]",
+    )
+    metadata_index = param.List(
+        default=[
+            65026,  # "ManufacturerStr:Andor"
+            65027,  # "ExposureTime:70.000000"
+            65068,  # "MotSlitHR.RBV:10.000000"
+            65070,  # "MotSlitHL.RBV:20.000000"
+            65066,  # "MotSlitVT.RBV:10.000000"
+            65068,  # "MotSlitHR.RBV:10.000000"
+        ],
+        doc="list of metadata keys to be extracted from the file.",
+    )
+    metadata = param.Dict(
+        default={},
+        doc="dictionary of metadata extracted from the file.",
+    )
+    relative_tolerance = param.Number(
+        default=0.01,
+        doc="relative tolerance for comparing metadata values.",
+    )
+
+    @property
+    def suffix(self) -> str:
+        return Path(self.filename).suffix
+
+    @param.depends("filename", "datatype", watch=True, on_init=True)
+    def _update_metadata_index(self):
+        """
+        Update metadata index
+        """
+        if self.suffix.lower() in (".tiff", "tif"):
+            # NOTE: trim slits position from metadata_keys if the file is
+            #       dark current file
+            if self.datatype in ("darkcurrent", "dc"):
+                self.metadata_index = [65026, 65027]
+        elif self.suffix.lower() in (".fits", ".fit"):
+            raise NotImplementedError
+
+    @param.depends("filename", "metadata_index", watch=True, on_init=True)
+    def _update_metadata(self):
+        if self.suffix.lower() in (".tiff", "tif"):
+            self.metadata = _extract_metadata_from_tiff(self.filename, self.metadata_index)
+        elif self.suffix.lower() in (".fits", ".fit"):
+            raise NotImplementedError
+
+    def __eq__(self, other):
+        if not isinstance(other, MetaData):
+            raise NotImplementedError
+        # find the most common keys
+        common_keys = [k for k in self.metadata.keys() if k in other.metadata.keys()]
+        # check all entries
+        is_match = True
+        for k in common_keys:
+            me = self.metadata[k]
+            te = other.metadata[k]
+            if isinstance(me, str):
+                is_match = (me == te) and is_match
+            elif isinstance(me, float):
+                is_match = (np.isclose(me, te, rtol=self.relative_tolerance)) and is_match
+            # break early if is_match if false
+            if not is_match:
+                break
+        return is_match
+
+    def match(self, other_filename: str, other_datatype: str) -> bool:
+        # instantiate metadata for other file
+        other = MetaData(filename=other_filename, datatype=other_datatype)
+        return self == other
+
+
+def _extract_metadata_from_tiff(
+    filename: str,
+    index: list[int],
+) -> dict:
+    """
+    Extract metadata from tiff file.
+
+    Parameters
+    ----------
+    filename :
+        full path to the tiff file.
+    index :
+        list of metadata keys/index to be extracted from tiff tags.
+
+    Returns
+    -------
+    metadata :
+        dictionary of metadata extracted from the tiff file.
+    """
+    tiff = tifffile.TiffFile(filename)
+    metadata = dict([tiff.pages[0].tags[i].value.split(":") for i in index])
+    # map to correct type
+    for k, v in metadata.items():
+        try:
+            v = float(v)
+        except ValueError:
+            pass
+        metadata[k] = v
+    return metadata

--- a/tests/unit/backend/io/test_metadata.py
+++ b/tests/unit/backend/io/test_metadata.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""
+Unit tests for backend metadata auxiliary class.
+"""
+import os
+import pytest
+import numpy as np
+import tifffile
+from imars3d.backend.io.metadata import MetaData
+from imars3d.backend.io.metadata import _extract_metadata_from_tiff
+
+
+@pytest.fixture(scope="module")
+def test_data():
+    # create testing tiff images
+    data = np.ones((3, 3))
+    #
+    ext_tags_ct = [
+        (65026, "s", 0, "ManufacturerStr:Test", True),
+        (65027, "s", 0, "ExposureTime:70.000000", True),
+        (65068, "s", 0, "MotSlitHR.RBV:10.000000", True),
+        (65070, "s", 0, "MotSlitHL.RBV:20.000000", True),
+        (65066, "s", 0, "MotSlitVT.RBV:10.000000", True),
+        (65068, "s", 0, "MotSlitHR.RBV:10.000000", True),
+    ]
+    ext_tags_dc = [
+        (65026, "s", 0, "ManufacturerStr:Test", True),
+        (65027, "s", 0, "ExposureTime:70.000000", True),
+    ]
+    ext_tags_ct_alt = [
+        (65026, "s", 0, "ManufacturerStr:Test", True),
+        (65027, "s", 0, "ExposureTime:71.000000", True),
+        (65068, "s", 0, "MotSlitHR.RBV:11.000000", True),
+        (65070, "s", 0, "MotSlitHL.RBV:21.000000", True),
+        (65066, "s", 0, "MotSlitVT.RBV:11.000000", True),
+        (65068, "s", 0, "MotSlitHR.RBV:11.000000", True),
+    ]
+    # write testing data
+    tifffile.imwrite("test_ct.tiff", data, extratags=ext_tags_ct)
+    tifffile.imwrite("test_ob.tiff", data, extratags=ext_tags_ct)
+    tifffile.imwrite("test_dc.tiff", data, extratags=ext_tags_dc)
+    tifffile.imwrite("test_ct_alt.tiff", data, extratags=ext_tags_ct_alt)
+    yield
+    # cleanup
+    os.remove("test_ct.tiff")
+    os.remove("test_ob.tiff")
+    os.remove("test_dc.tiff")
+    os.remove("test_ct_alt.tiff")
+
+
+def test_metadata(test_data):
+    metadata_ct = MetaData(filename="test_ct.tiff", datatype="ct")
+    metadata_ob = MetaData(filename="test_ob.tiff", datatype="ob")
+    metadata_dc = MetaData(filename="test_dc.tiff", datatype="dc")
+    metadata_ct_alt = MetaData(filename="test_ct_alt.tiff", datatype="ct")
+    # ct and ob, dc should match
+    assert metadata_ct == metadata_ob
+    assert metadata_ct == metadata_dc
+    assert metadata_ct.match(other_filename="test_ob.tiff", other_datatype="ob")
+    assert metadata_ct.match(other_filename="test_dc.tiff", other_datatype="dc")
+    # ct_alt and ob, dc should not match
+    assert metadata_ct != metadata_ct_alt
+    assert metadata_ct_alt != metadata_ob
+    assert metadata_ct_alt != metadata_dc
+    assert not metadata_ct_alt.match(other_filename="test_ob.tiff", other_datatype="ob")
+    assert not metadata_ct_alt.match(other_filename="test_dc.tiff", other_datatype="dc")
+
+
+def test_extract_metadata_from_tiff(test_data):
+    test_filename = "test_ct.tiff"
+    test_index = [65026, 65027]
+    #
+    ref = {"ManufacturerStr": "Test", "ExposureTime": 70.0}
+    #
+    assert _extract_metadata_from_tiff(test_filename, test_index) == ref
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])

--- a/tests/unit/backend/io/test_metadata.py
+++ b/tests/unit/backend/io/test_metadata.py
@@ -40,12 +40,15 @@ def test_data():
     tifffile.imwrite("test_ob.tiff", data, extratags=ext_tags_ct)
     tifffile.imwrite("test_dc.tiff", data, extratags=ext_tags_dc)
     tifffile.imwrite("test_ct_alt.tiff", data, extratags=ext_tags_ct_alt)
+    # for extension checking
+    tifffile.imwrite("test.fits", data)
     yield
     # cleanup
     os.remove("test_ct.tiff")
     os.remove("test_ob.tiff")
     os.remove("test_dc.tiff")
     os.remove("test_ct_alt.tiff")
+    os.remove("test.fits")
 
 
 def test_metadata(test_data):
@@ -64,6 +67,15 @@ def test_metadata(test_data):
     assert metadata_ct_alt != metadata_dc
     assert not metadata_ct_alt.match(other_filename="test_ob.tiff", other_datatype="ob")
     assert not metadata_ct_alt.match(other_filename="test_dc.tiff", other_datatype="dc")
+
+
+def test_not_implemented(test_data):
+    with pytest.raises(NotImplementedError):
+        MetaData(filename="test.fits", datatype="ct")
+    #
+    metadata_ct = MetaData(filename="test_ct.tiff", datatype="ct")
+    with pytest.raises(NotImplementedError):
+        metadata_ct.match(other_filename="test.fits", other_datatype="ct")
 
 
 def test_extract_metadata_from_tiff(test_data):

--- a/tests/unit/backend/io/test_metadata.py
+++ b/tests/unit/backend/io/test_metadata.py
@@ -10,7 +10,7 @@ from imars3d.backend.io.metadata import _extract_metadata_from_tiff
 
 
 @pytest.fixture(scope="module")
-def test_data(tmpdir_factory):
+def data_fixture(tmpdir_factory):
     # create testing tiff images
     data = np.ones((3, 3))
     #
@@ -49,8 +49,8 @@ def test_data(tmpdir_factory):
     return ct, ob, dc, ct_alt, fits
 
 
-def test_metadata(test_data):
-    ct, ob, dc, ct_alt, _ = list(map(str, test_data))
+def test_metadata(data_fixture):
+    ct, ob, dc, ct_alt, _ = list(map(str, data_fixture))
     metadata_ct = MetaData(filename=ct, datatype="ct")
     metadata_ob = MetaData(filename=ob, datatype="ob")
     metadata_dc = MetaData(filename=dc, datatype="dc")
@@ -68,8 +68,8 @@ def test_metadata(test_data):
     assert not metadata_ct_alt.match(other_filename=dc, other_datatype="dc")
 
 
-def test_not_implemented(test_data):
-    ct, ob, dc, ct_alt, fits = list(map(str, test_data))
+def test_not_implemented(data_fixture):
+    ct, ob, dc, ct_alt, fits = list(map(str, data_fixture))
     with pytest.raises(ValueError):
         MetaData(filename=fits, datatype="ct")
     #
@@ -78,8 +78,8 @@ def test_not_implemented(test_data):
         metadata_ct.match(other_filename=fits, other_datatype="ct")
 
 
-def test_extract_metadata_from_tiff(test_data):
-    ct, ob, dc, ct_alt, fits = list(map(str, test_data))
+def test_extract_metadata_from_tiff(data_fixture):
+    ct, ob, dc, ct_alt, fits = list(map(str, data_fixture))
     test_filename = ct
     test_index = [65026, 65027]
     #


### PR DESCRIPTION
Original Gitlab Task: [IMG336](https://code.ornl.gov/sns-hfir-scse/imaging/imaging/-/issues/336)

This PR introduces a new MetaData class that can extract the metadata from a given file (only support tiff for now).
It can be used to check if two files were taken in the same scan by checking its metadata record (a subset).

