### PR TITLE
deprecated prefix "globals."

### DIFF
--- a/tests/data/json/good_non_interactive.json
+++ b/tests/data/json/good_non_interactive.json
@@ -12,30 +12,30 @@
             "inputs": {
                 "filenames": []
             },
-            "outputs": ["globals.ct"]
+            "outputs": ["ct"]
         },
         {
             "name": "gamma",
             "function": "imars3d.backend.corrections.gamma_filter.GammaFilter",
             "inputs": {
-                "ct_series": "globals.ct",
-                "workdir": "globals.workingdir"
+                "ct_series": "ct",
+                "workdir": "workingdir"
             },
-            "outputs": ["globals.ct"]
+            "outputs": ["ct"]
         },
         {
             "name": "save",
             "function": "imars3d.backend.io.data.save_data",
             "inputs": {
-                "ct_series": "globals.ct",
-                "path": "globals.workingdir"
+                "ct_series": "ct",
+                "path": "workingdir"
             }
         },
         {
             "name": "determine_tilt_correction",
             "function": "imars3d.backend.diagnostics.tilt.tilt_correction",
             "inputs": {
-                "ct_series": "globals.ct"
+                "ct_series": "ct"
             },
             "outputs": ["tilt_angle"]
         },
@@ -43,17 +43,17 @@
             "name": "tilt_corection",
             "function": "imars3d.backend.diagnostics.tilt.apply_tilt_correction_correction",
             "inputs": {
-                "ct_series": "globals.ct",
+                "ct_series": "ct",
                 "angle": "determine_tilt_correction.tilt_angle"
             },
-            "outputs": ["globals.ct"]
+            "outputs": ["ct"]
         },
         {
             "name": "save",
             "function": "imars3d.backend.io.data.save_data",
             "inputs": {
-                "ct_series": "globals.ct",
-                "path": "globals.ouputdir"
+                "ct_series": "ct",
+                "path": "ouputdir"
             }
         }
     ]


### PR DESCRIPTION
Because ["global parameters" are like reserved keywords](https://github.com/ornlneutronimaging/iMars3D/blob/next/src/imars3d/backend/workflow/validate.py#L17), the use of prefix "globals." in JSON files become unnecessary. 