### PR TITLE
Test cades runner for integration tests

### DIFF
--- a/.github/workflows/protected_branches.yml
+++ b/.github/workflows/protected_branches.yml
@@ -6,8 +6,27 @@ on:
     branches: [next, qa, main]
 
 jobs:
+  integration-tests:
+    runs-on: cades
+    defaults:
+      run:
+        shell: bash -l {0}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
+          lfs: true
+      - uses: conda-incubator/setup-miniconda@v2
+        with:
+          miniforge-variant: Mambaforge
+          environment-file: conda_development.yml
+          use-mamba: true
+      - name: Unit integration tests
+        run: python -m pytest tests/integration
+
   build-conda:
     runs-on: ubuntu-latest
+    needs: [integration-tests]
     defaults:
       run:
         shell: bash -l {0}

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "tests/data/imars3d-data"]
+	path = tests/data/imars3d-data
+	url = https://code.ornl.gov/sns-hfir-scse/infrastructure/test-data/imars3d-data.git

--- a/src/imars3d/backend/workflow/validate.py
+++ b/src/imars3d/backend/workflow/validate.py
@@ -25,6 +25,7 @@ GLOBAL_PARAMS = {
     "dc",  # array of dark current intensities
     "tilt_angle",
     "rot_center",
+    "rot_angles",
 }
 
 

--- a/tests/integration/backend/test_backend.py
+++ b/tests/integration/backend/test_backend.py
@@ -1,0 +1,41 @@
+# backend module integration tests
+
+# create json test data
+import json
+
+from imars3d.backend.workflow.engine import WorkflowEngineAuto
+import pytest
+
+
+@pytest.fixture(scope="module")
+def config():
+    config_str = """
+{
+    "facility": "HFIR",
+    "instrument": "CG1D",
+    "ipts": "IPTS-1234",
+    "name": "name for reconstructed ct scans",
+    "workingdir": "/path/to/working/dir",
+    "outputdir": "/path/to/output/dir",
+    "tasks": [{
+    "name": "task1",
+    "function": "imars3d.backend.io.data.load_data",
+    "inputs": {
+    "ct_dir": "tests/data/imars3d-data/HFIR/CG1D/IPTS-25777/raw/ct_scans/iron_man",
+    "ob_dir": "tests/data/imars3d-data/HFIR/CG1D/IPTS-25777/raw/ob/Oct29_2019/",
+    "dc_dir": "tests/data/imars3d-data/HFIR/CG1D/IPTS-25777/raw/df/Oct29_2019/",
+    "ct_fnmatch": "*.tiff",
+    "ob_fnmatch": "*.tiff",
+    "dc_fnmatch": "*.tiff"
+    },
+    "outputs": ["ct", "ob", "dc", "rot_angles"]
+    }
+    ]
+}"""
+    return json.loads(config_str)
+
+
+class TestWorkflowEngineAuto:
+    def test_config(self, config):
+        workflow = WorkflowEngineAuto(config)
+        workflow.run()


### PR DESCRIPTION
Add imars3d-data as submodule

Add simple test that just loads the data

Integration running at https://github.com/ornlneutronimaging/iMars3D/actions/runs/3330408810