### PR TITLE
Annotate build with integration test status

### DIFF
--- a/.github/workflows/protected_branches.yml
+++ b/.github/workflows/protected_branches.yml
@@ -12,10 +12,6 @@ jobs:
       run:
         shell: bash -l {0}
     steps:
-      - uses: actions/checkout@v3
-        with:
-          submodules: true
-          lfs: true
       - name: Add pending status
         uses: Sibz/github-status-action@v1
         if: ${{ github.event_name == 'workflow_dispatch' }}
@@ -25,7 +21,11 @@ jobs:
           description: "pending"
           state: "pending"
           sha: "${{ github.sha }}"
-          target_url: "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          target_url: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
+          lfs: true
       - uses: conda-incubator/setup-miniconda@v2
         with:
           miniforge-variant: Mambaforge
@@ -42,7 +42,7 @@ jobs:
           description: "${{ job.status }}"
           state: "${{ job.status }}"
           sha: "${{ github.sha }}"
-          target_url: "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          target_url: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
   build-conda:
     runs-on: ubuntu-latest

--- a/.github/workflows/protected_branches.yml
+++ b/.github/workflows/protected_branches.yml
@@ -21,8 +21,23 @@ jobs:
           miniforge-variant: Mambaforge
           environment-file: conda_development.yml
           use-mamba: true
+      - name: Add status to commit
+        uses: peter-evans/commit-comment@v2
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        with:
+          body: |
+            Github job ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}
       - name: Unit integration tests
         run: python -m pytest tests/integration
+      - name: Add status to commit
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        uses: Sibz/github-status-action@v1
+        with:
+          authToken: ${{secrets.GITHUB_TOKEN}}
+          context: "Integration tests"
+          description: "${{ job.status }}"
+          state: "${{ job.status }}"
+          sha: "${{ github.sha }}"
 
   build-conda:
     runs-on: ubuntu-latest

--- a/.github/workflows/protected_branches.yml
+++ b/.github/workflows/protected_branches.yml
@@ -16,21 +16,33 @@ jobs:
         with:
           submodules: true
           lfs: true
+      - name: Add pending status
+        uses: Sibz/github-status-action@v1
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        with:
+          authToken: ${{secrets.GITHUB_TOKEN}}
+          context: "Integration tests"
+          description: "pending"
+          state: "pending"
+          sha: "${{ github.sha }}"
+          target_url: "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
       - uses: conda-incubator/setup-miniconda@v2
         with:
           miniforge-variant: Mambaforge
           environment-file: conda_development.yml
           use-mamba: true
-      - name: Add pending status
-        uses: ouzi-dev/commit-status-updater@v2
-        if: ${{ always() && github.event_name == 'workflow_dispatch' }}
       - name: Unit integration tests
         run: python -m pytest tests/integration
       - name: Update job status
+        uses: Sibz/github-status-action@v1
         if: ${{ always() && github.event_name == 'workflow_dispatch' }}
-        uses: ouzi-dev/commit-status-updater@v2
         with:
-          status: "${{ job.status }}"
+          authToken: ${{secrets.GITHUB_TOKEN}}
+          context: "Integration tests"
+          description: "${{ job.status }}"
+          state: "${{ job.status }}"
+          sha: "${{ github.sha }}"
+          target_url: "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
 
   build-conda:
     runs-on: ubuntu-latest

--- a/.github/workflows/protected_branches.yml
+++ b/.github/workflows/protected_branches.yml
@@ -21,23 +21,16 @@ jobs:
           miniforge-variant: Mambaforge
           environment-file: conda_development.yml
           use-mamba: true
-      - name: Add status to commit
-        uses: peter-evans/commit-comment@v2
-        if: ${{ github.event_name == 'workflow_dispatch' }}
-        with:
-          body: |
-            Github job ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}
+      - name: Add pending status
+        uses: ouzi-dev/commit-status-updater@v2
+        if: ${{ always() && github.event_name == 'workflow_dispatch' }}
       - name: Unit integration tests
         run: python -m pytest tests/integration
-      - name: Add status to commit
-        if: ${{ github.event_name == 'workflow_dispatch' }}
-        uses: Sibz/github-status-action@v1
+      - name: Update job status
+        if: ${{ always() && github.event_name == 'workflow_dispatch' }}
+        uses: ouzi-dev/commit-status-updater@v2
         with:
-          authToken: ${{secrets.GITHUB_TOKEN}}
-          context: "Integration tests"
-          description: "${{ job.status }}"
-          state: "${{ job.status }}"
-          sha: "${{ github.sha }}"
+          status: "${{ job.status }}"
 
   build-conda:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Borrowing from the idea of [this chunk of code](https://github.com/nguyenvanuyn96/Test-Automate-Release-Framework/blob/develop/.github/workflows/PR%20Eligibility%20Check%20workflows.yml#L155-L171). 

According to the [docs on environment variables](https://docs.github.com/en/actions/learn-github-actions/environment-variables), it may be better to just comment on the commit with `$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID` using `peter-evans/commit-comment`.