### PR TITLE
implement assisted_window.py

### DIFF
--- a/src/imars3d/ui/assisted_window.py
+++ b/src/imars3d/ui/assisted_window.py
@@ -71,6 +71,8 @@ class AssistedWindow(BaseWindow):
         left_column = pn.Column(self.go_button, self.log_level_radio, self.console, sizing_mode='stretch_both')
         right_column = pn.Column(self.json_editor(), self.file_input, sizing_mode='stretch_both')
         self._panel = pn.Row(left_column, right_column)
+        
+        self.wfEngine = WorkflowEngineAuto(self.config_dict)
 
     @param.depends('log_level_str', watch=True)
     def set_log_level(self):
@@ -82,9 +84,13 @@ class AssistedWindow(BaseWindow):
     def update_config_dict(self):
         logger.info("Updating config dict with uploaded json file.")
         new_config_dict = json.loads(self.file_input.value)
-        self.config_dict=new_config_dict
+        try:
+            self.wfEngine = WorkflowEngineAuto(new_config_dict)
+            self.config_dict = new_config_dict
+        except:
+            log.error("Could not update config file. Reverting to previous config.")
+            self.wfEngine = WorkflowEngineAuto(self.config_dict)
    
     def launch_assisted_reconstruction(self, event): 
-        logger.info('Launching assisted reconstruction')
-        wfEngine = WorkflowEngineAuto(self.config_dict)
-        wfEngine.run()
+        logger.info('Launching assisted reconstruction.')
+        self.wfEngine.run()

--- a/src/imars3d/ui/assisted_window.py
+++ b/src/imars3d/ui/assisted_window.py
@@ -24,59 +24,54 @@ from imars3d.backend.workflow.engine import WorkflowEngineAuto
 
 logger = logging.getLogger(__name__)
 
+
 class AssistedWindow(BaseWindow):
     """Sub-app for assisted reconstruction."""
-    
+
     log_level_str = param.Selector(
-        default="INFO", 
+        default="INFO",
         objects=["INFO", "DEBUG", "WARNING", "ERROR", "CRITICAL"],
-        doc="Level of logging in the console."
+        doc="Level of logging in the console.",
     )
-    
+
     log_level = param.Selector(
         default=logging.INFO,
         objects=[logging.INFO, logging.DEBUG, logging.WARNING, logging.ERROR, logging.CRITICAL],
-        doc="Level of logging in the console."
+        doc="Level of logging in the console.",
     )
-    
-    file_input = pn.widgets.FileInput(
-            accept='.json'
-    )
-    
+
+    file_input = pn.widgets.FileInput(accept=".json")
+
     def __init__(self, **params):
         super().__init__(**params)
 
         self.log_level = logging.INFO
-        self.go_button = pn.widgets.Button(
-            name='GO', 
-            button_type='primary',
-            width=100
-        )
+        self.go_button = pn.widgets.Button(name="GO", button_type="primary", width=100)
         self.go_button.on_click(self.launch_assisted_reconstruction)
-        
+
         self.log_level_radio = pn.widgets.RadioButtonGroup.from_param(
-             self.param.log_level_str,
-             name="Debugger Level",
-             tooltips="Select debugger level",      
+            self.param.log_level_str,
+            name="Debugger Level",
+            tooltips="Select debugger level",
         )
-        
+
         self.console = pn.widgets.Debugger(
-            name='Debugger', 
-            level=self.log_level, 
-            sizing_mode='stretch_width',
+            name="Debugger",
+            level=self.log_level,
+            sizing_mode="stretch_width",
             logger_names=["panel", "imars3d"],
         )
-        left_column = pn.Column(self.go_button, self.log_level_radio, self.console, sizing_mode='stretch_both')
-        right_column = pn.Column(self.json_editor(), self.file_input, sizing_mode='stretch_both')
+        left_column = pn.Column(self.go_button, self.log_level_radio, self.console, sizing_mode="stretch_both")
+        right_column = pn.Column(self.json_editor(), self.file_input, sizing_mode="stretch_both")
         self._panel = pn.Row(left_column, right_column)
 
-    @param.depends('log_level_str', watch=True)
+    @param.depends("log_level_str", watch=True)
     def set_log_level(self):
         self.log_level = logging.getLevelName(self.log_level_str)
         logging.getLogger("imars3d").setLevel(self.log_level)
         logger.log(self.log_level, f"Switching to {self.log_level_str} log level.")
-        
-    @param.depends("file_input.value", watch=True) 
+
+    @param.depends("file_input.value", watch=True)
     def update_config_dict(self):
         logger.info("Updating config dict with uploaded json file.")
         new_config_dict = json.loads(self.file_input.value)
@@ -86,8 +81,8 @@ class AssistedWindow(BaseWindow):
             self.config_dict = new_config_dict
         except:
             logger.error("Could not update config file. Reverting to previous config.")
-   
-    def launch_assisted_reconstruction(self, event): 
-        logger.info('Launching assisted reconstruction.')
+
+    def launch_assisted_reconstruction(self, event):
+        logger.info("Launching assisted reconstruction.")
         wfEngine = WorkflowEngineAuto(self.config_dict)
         wfEngine.run()

--- a/src/imars3d/ui/assisted_window.py
+++ b/src/imars3d/ui/assisted_window.py
@@ -16,17 +16,75 @@ assisted_window  # or pn.panel(assisted_window) or assisted_window.show() or ass
 """
 import panel as pn
 import param
+import json
+import sys
 from imars3d.ui.base_window import BaseWindow
+from imars3d.backend.workflow.engine import WorkflowEngineAuto
 
-logger = param.get_logger(__name__)
+import logging
 
+
+logger = logging.getLogger(__name__)
 
 class AssistedWindow(BaseWindow):
     """Sub-app for assisted reconstruction."""
-
+    
+    log_level_str = param.Selector(
+        default="INFO", 
+        objects=["INFO", "DEBUG", "WARNING", "ERROR", "CRITICAL"],
+        doc="Level of logging in the console."
+    )
+    
+    log_level = param.Selector(
+        default=logging.INFO,
+        objects=[logging.INFO, logging.DEBUG, logging.WARNING, logging.ERROR, logging.CRITICAL],
+        doc="Level of logging in the console."
+    )
+    
+    file_input = pn.widgets.FileInput(
+            accept='.json'
+    )
+    
     def __init__(self, **params):
         super().__init__(**params)
-        self._panel = pn.panel("**Assisted reconstruction window.**")
 
-    def __panel__(self):
-        return self._panel
+        self.log_level = logging.INFO
+        self.go_button = pn.widgets.Button(
+            name='GO', 
+            button_type='primary',
+            width=100
+        )
+        self.go_button.on_click(self.launch_assisted_reconstruction)
+        
+        self.log_level_radio = pn.widgets.RadioButtonGroup.from_param(
+             self.param.log_level_str,
+             name="Debugger Level",
+             tooltips="Select debugger level",      
+        )
+        
+        self.console = pn.widgets.Debugger(
+            name='Debugger', 
+            level=self.log_level, 
+            sizing_mode='stretch_width',
+            logger_names=["panel", "imars3d"],
+        )
+        left_column = pn.Column(self.go_button, self.log_level_radio, self.console, sizing_mode='stretch_both')
+        right_column = pn.Column(self.json_editor(), self.file_input, sizing_mode='stretch_both')
+        self._panel = pn.Row(left_column, right_column)
+
+    @param.depends('log_level_str', watch=True)
+    def set_log_level(self):
+        self.log_level = logging.getLevelName(self.log_level_str)
+        logging.getLogger("imars3d").setLevel(self.log_level)
+        logger.log(self.log_level, f"Switching to {self.log_level_str} log level.")
+        
+    @param.depends("file_input.value", watch=True) 
+    def update_config_dict(self):
+        logger.info("Updating config dict with uploaded json file.")
+        new_config_dict = json.loads(self.file_input.value)
+        self.config_dict=new_config_dict
+   
+    def launch_assisted_reconstruction(self, event): 
+        logger.info('Launching assisted reconstruction')
+        wfEngine = WorkflowEngineAuto(self.config_dict)
+        wfEngine.run()

--- a/src/imars3d/ui/assisted_window.py
+++ b/src/imars3d/ui/assisted_window.py
@@ -71,8 +71,6 @@ class AssistedWindow(BaseWindow):
         left_column = pn.Column(self.go_button, self.log_level_radio, self.console, sizing_mode='stretch_both')
         right_column = pn.Column(self.json_editor(), self.file_input, sizing_mode='stretch_both')
         self._panel = pn.Row(left_column, right_column)
-        
-        self.wfEngine = WorkflowEngineAuto(self.config_dict)
 
     @param.depends('log_level_str', watch=True)
     def set_log_level(self):
@@ -85,12 +83,13 @@ class AssistedWindow(BaseWindow):
         logger.info("Updating config dict with uploaded json file.")
         new_config_dict = json.loads(self.file_input.value)
         try:
-            self.wfEngine = WorkflowEngineAuto(new_config_dict)
+            # Validating new config file by instantiating WorkflowEngineAuto
+            validate_dict = WorkflowEngineAuto(new_config_dict)
             self.config_dict = new_config_dict
         except:
             log.error("Could not update config file. Reverting to previous config.")
-            self.wfEngine = WorkflowEngineAuto(self.config_dict)
    
     def launch_assisted_reconstruction(self, event): 
         logger.info('Launching assisted reconstruction.')
-        self.wfEngine.run()
+        wfEngine = WorkflowEngineAuto(self.config_dict)
+        wfEngine.run()

--- a/src/imars3d/ui/assisted_window.py
+++ b/src/imars3d/ui/assisted_window.py
@@ -87,7 +87,7 @@ class AssistedWindow(BaseWindow):
             validate_dict = WorkflowEngineAuto(new_config_dict)
             self.config_dict = new_config_dict
         except:
-            log.error("Could not update config file. Reverting to previous config.")
+            logger.error("Could not update config file. Reverting to previous config.")
    
     def launch_assisted_reconstruction(self, event): 
         logger.info('Launching assisted reconstruction.')


### PR DESCRIPTION
Addresses issue [385](https://code.ornl.gov/sns-hfir-scse/imaging/imaging/-/issues/385). 
One thing to point is that the config_dict doesn't initially show up in the json_editor in base_window.py. However, it is sent correctly to the workflow engine, it's purely visual, so I was wondering if you know how to fix that issue.

To test I followed the same process as here:  https://github.com/ornlneutronimaging/iMars3D/pull/205
To test the ui manually, make sure you testing environment can see /HFIR/CG1D/IPTS-25777/ (on analysis or via sshfs), use the following code

```python
import panel as pn
from imars3d.ui.main import MainWindow

pn.extension(
    "vtk",  # for the 3D viewer
    "terminal",  # or the console
    "jsoneditor",  # for config viewer
    nthreads=0,
    notifications=True,
)
main_window = MainWindow()
main_window  # or pn.panel(main_window) or main_window.show() or main_window.servable()
```

The instrument should be CG1D and the IPTS number should be 25777.
Set the experiment name to iron_man_8cz_py310.