### PR TITLE
[IMG290] Add new crop widget for interactive cropping

### DIFF
--- a/src/imars3d/__init__.py
+++ b/src/imars3d/__init__.py
@@ -1,5 +1,6 @@
 """iMars3D: a Python package for neutron imaging and tomography reconstruction."""
 import logging
+from .backend import corrections, diagnostics, io, morph, preparation, reconstruction
 
 logging.getLogger("imars3d").setLevel(logging.INFO)
 try:

--- a/src/imars3d/backend/io/__init__.py
+++ b/src/imars3d/backend/io/__init__.py
@@ -1,1 +1,2 @@
 """data handling module for iMars3D."""
+from . import data

--- a/src/imars3d/backend/morph/crop.py
+++ b/src/imars3d/backend/morph/crop.py
@@ -63,22 +63,31 @@ class crop(param.ParameterizedFunction):
     #
     # NOTE: fails early if the array dimension is incorrect
 
-    arrays = param.Array(doc="The image stack to crop. Can also be a 2D image.")
+    arrays = param.Array(
+        doc="The image stack to crop. Can also be a 2D image.",
+        precedence=-1,  # hide arrays from auto GUI
+    )
     crop_limit = param.Tuple(
         default=(-1, -1, -1, -1),
+        precedence=1,  # mandatory
         doc="The four limits for cropping. Default is (-1, -1, -1, -1), which will trigger the automatic bounds detection.",
     )
     border_pix = param.Integer(
         default=10,
+        precedence=0.5,  # advanced option
         doc="the width of border region to estimate the background intensity, which helps to determine which case we are in.",
     )
-    expand_ratio = param.Number(default=0.1, doc="The ratio to expand the cropped region.")
-    rel_intensity_threshold_air_or_slit = param.Number(
-        default=0.05, doc="Passing through keyword arguments to detect_bounds."
+    expand_ratio = param.Number(
+        default=0.1, precedence=0.4, doc="The ratio to expand the cropped region."  # advanced option
     )
-    rel_intensity_threshold_fov = param.Number(default=0.1, doc="Passing through keyword arguments to detect_bounds.")
+    rel_intensity_threshold_air_or_slit = param.Number(
+        default=0.05, precedence=0.3, doc="Passing through keyword arguments to detect_bounds."  # advanced option
+    )
+    rel_intensity_threshold_fov = param.Number(
+        default=0.1, precedence=0.2, doc="Passing through keyword arguments to detect_bounds."  # advanced option
+    )
     rel_intensity_threshold_sample = param.Number(
-        default=0.95, doc="Passing through keyword arguments to detect_bounds."
+        default=0.95, precedence=0.1, doc="Passing through keyword arguments to detect_bounds."  # advanced option
     )
 
     def __call__(self, **params):

--- a/src/imars3d/ui/util.py
+++ b/src/imars3d/ui/util.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""Helper functions for UI development.
+
+The functions in this module are for UI development only.
+In production, the functions should be replaced by the corresponding
+RunEngine in the backend module.
+
+To test
+
+from imars3d.ui.utils import run_task
+
+mtd = {}
+demo_task = {
+    "name": "load",
+    "function": "imars3d.backend.io.data.load_data",
+    "inputs": {
+        "ct_dir": "/HFIR//CG1D/IPTS-25777/raw/ct_scans/iron_man",
+        "ob_dir": "/HFIR/CG1D/IPTS-25777/raw/ob/Oct29_2019/",
+        "dc_dir": "/HFIR/CG1D/IPTS-25777/raw/df/Oct29_2019/",
+        "ct_fnmatch": "*.tiff",
+        "ob_fnmatch": "*.tiff",
+        "dc_fnmatch": "*.tiff"
+    },
+    "outputs": ["ct", "ob", "dc", "rot_angles"]
+}
+run_task(mtd, task=demo_task)
+"""
+
+
+def run_task(mtd, task):
+    """Temp solution to run individual tasks.
+
+    A permanent solution will be provided via RunEngine instead of using
+    eval.
+    """
+    # parse function handle
+    module_str = task["function"].split(".")[0]
+    func_str = ".".join(task["function"].split(".")[1:])
+    # prepare inputs
+    argstr = []
+    for k, v in task["inputs"].items():
+        if v in mtd:
+            argstr.append(f"{k}={v}")
+        else:
+            argstr.append(f"{k}='{v}'")
+    argstr = ",".join(argstr)
+    # build call str
+    evalstr = f"__import__('{module_str}').{func_str}({argstr})"
+    # call
+    rst = eval(evalstr, {}, mtd)
+    # update
+    for ok, ov in zip(task["outputs"], rst):
+        mtd[ok] = ov

--- a/src/imars3d/ui/viewer_window.py
+++ b/src/imars3d/ui/viewer_window.py
@@ -25,7 +25,7 @@ from imars3d.ui.widgets.viewer2d import Viewer2D
 from imars3d.ui.widgets.hyperstack_view import HyperstackView
 from imars3d.backend.io.data import _load_images
 
-logger = logging.getLogger("imars3d.ui.viewer_window")
+logger = logging.getLogger(__name__)
 
 
 class ViewerWindow(BaseWindow):

--- a/src/imars3d/ui/widgets/crop.py
+++ b/src/imars3d/ui/widgets/crop.py
@@ -62,7 +62,6 @@ class CropWidget(BaseWindow, Viewer2D):
     )
     # load data button
     load_data = param.Action(lambda x: x.param.trigger("load_data"))
-    record_roi = param.Action(lambda x: x.param.trigger("record_roi"))
     #
     roi_box = hv.Polygons([])
     roi_box_stream = streams.BoxEdit()

--- a/src/imars3d/ui/widgets/crop.py
+++ b/src/imars3d/ui/widgets/crop.py
@@ -1,0 +1,274 @@
+#!/usr/bin/env python3
+"""Crop widget for iMars3D.
+
+To test this widget in isolation within Jupyter, do the following:
+
+    import panel as pn
+    import holoviews as hv
+    from imars3d.ui.widgets.crop import CropWidget
+
+    pn.extension()
+    hv.extension('bokeh')
+
+    crop_widget = CropWidget()
+    # manual update the embedded config to make sure the load task
+    # has valid entries as we will be using those to test the widget.
+    crop_widget.config_dict[tasks] = [
+        {
+            "name": "load",
+            "function": "imars3d.backend.io.data.load_data",
+            "inputs": {
+                "ct_dir": "/HFIR/CG1D/IPTS-25777/raw/ct_scans/iron_man",
+                "ob_dir": "/HFIR/CG1D/IPTS-25777/raw/ob/Oct29_2019/",
+                "dc_dir": "/HFIR/CG1D/IPTS-25777/raw/df/Oct29_2019/",
+                "ct_fnmatch": "*.tiff",
+                "ob_fnmatch": "*.tiff",
+                "dc_fnmatch": "*.tiff"
+            },
+            "outputs": ["ct", "ob", "dc", "rot_angles"]
+        }
+    ]
+
+    crop_widget  # or pn.panel(viewer_window) or viewer_window.show() or viewer_window.servable()
+
+    }
+"""
+import logging
+import param
+import numpy as np
+import panel as pn
+import holoviews as hv
+from holoviews import opts
+from holoviews import streams
+from imars3d.ui.base_window import BaseWindow
+from imars3d.ui.widgets.viewer2d import Viewer2D
+from imars3d.backend.morph.crop import crop
+
+logger = logging.getLogger(__name__)
+
+
+class CropWidget(BaseWindow, Viewer2D):
+    """Crop widget to allow user specify crop region in interactively."""
+
+    # toggles
+    show_advanced = param.Boolean(
+        default=False,
+        doc="whether to display advaned options with predence less than 0.5.",
+    )
+    crop_darkcurrent = param.Boolean(
+        default=True,
+        doc="if dark currents are used, it must be cropped here.",
+    )
+    # load data button
+    load_data = param.Action(lambda x: x.param.trigger("load_data"))
+    record_roi = param.Action(lambda x: x.param.trigger("record_roi"))
+    #
+    roi_box = hv.Polygons([])
+    roi_box_stream = streams.BoxEdit()
+
+    def __init__(self, data, **params):
+        super().__init__(data=data, **params)
+
+        self.func_name = f"{crop.__module__}.crop"
+
+        # func panel
+        # NOTE:
+        #   1. the functional panel is directly translated from the function signature.
+        #   2. the input arrays/ct/ob/dc are masked with precedence=-1 so that they don't
+        #      show up in the GUI
+        #   3. the value retrieving is done via simple name matching.
+        self.func_panel = pn.Param(
+            crop,
+            display_threshold=0.6,  # default to hide advanced options
+        )
+        show_advanced_checkbox = pn.widgets.Checkbox.from_param(
+            self.param.show_advanced,
+            name="Advanced Options",
+        )
+        crop_darkcurrent_checkbox = pn.widgets.Checkbox.from_param(
+            self.param.crop_darkcurrent,
+            name="Crop DarkCurrent",
+        )
+        #
+        func_pn = pn.Column(
+            self.func_panel,
+            crop_darkcurrent_checkbox,
+            show_advanced_checkbox,
+        )
+
+        # viewer pane
+        load_data_button = pn.widgets.Button.from_param(
+            self.param.load_data,
+            name="Load projected radiographs",
+        )
+        #
+        view_pn = pn.Column(
+            load_data_button,
+            pn.Row(
+                self.view_control_panel,
+                self.viewer,
+                sizing_mode="stretch_width",
+            ),
+        )
+
+        # complete view
+        self._panel = pn.Row(func_pn, view_pn)
+
+        # trigger update in case data is set during init
+        self.data = data
+
+    @param.depends("load_data", watch=True)
+    def load_data_action(self):
+        logger.info("Start loading data")
+        # looking for load function in config_dict
+        tasks = self.config_dict["tasks"]
+        load_task = None
+        for task in tasks:
+            if task["function"] == "imars3d.backend.io.data.load_data":
+                load_task = task
+                break
+        if load_task is None:
+            logger.warning("No task entry for loading data.")
+        else:
+            inputs = load_task["inputs"]
+            argstr = ", ".join([f"{k}={v}" for k, v in inputs.items()])
+            funcstr = f"load({argstr})"
+            ct, ob, dc, rot_angs = eval(funcstr)
+            self.data = np.sum(ct, axis=0)
+            # clean up
+            ct, ob, dc, rot_angs = 0, 0, 0, 0
+            del ct
+            del ob
+            del dc
+            del rot_angs
+
+    @param.depends(
+        "data",
+        "idx_data",
+        "colormap",
+        "colormap_scale",
+    )
+    def viewer(self):
+        if self.data is None:
+            return pn.panel("No radiograph loaded.")
+        else:
+            img = hv.Image(
+                (
+                    np.arange(self.data.shape[1]),
+                    np.arange(self.data.shape[0]),
+                    self.data,
+                ),
+                kdims=["x", "y"],
+                vdims=["count"],
+            )
+            self.roi_box_stream = streams.BoxEdit(source=self.roi_box, num_objects=1)
+            #
+            def update_roi(data):
+                """Internal function.
+
+                This function tricks Bokeh into updating the crop panel limit whenever
+                a valid ROI selection is provided.
+                """
+                try:
+                    top = int(data["y1"][0])
+                    bottom = int(data["y0"][0])
+                    left = int(data["x0"][0])
+                    right = int(data["x1"][0])
+                    self.update_crop_limit(top, bottom, left, right)
+                    return hv.Text(0, -10, "Trick bokeh to update ROI.")
+                except:
+                    logger.debug("no ROI found.")
+                    return hv.Text(0, -10, "Trick bokeh to update ROI.")
+
+            dmap = hv.DynamicMap(update_roi, streams=[self.roi_box_stream])
+            #
+            return (img.hist() * self.roi_box * dmap).opts(
+                opts.Image(
+                    tools=["hover"],
+                    cmap=self.colormap,
+                    cnorm=self.colormap_scale,
+                    data_aspect=1.0,
+                    invert_yaxis=True,
+                    xaxis=None,
+                    yaxis=None,
+                ),
+                opts.Polygons(
+                    fill_alpha=0.2,
+                    line_color="red",
+                ),
+            )
+
+    def update_crop_limit(self, top, bottom, left, right):
+        """Update the crop limit in the function panel."""
+        for w in self.func_panel:
+            if w.name.lower().replace(" ", "_") == "crop_limit":
+                w.value = (top, bottom, left, right)
+
+    @param.depends("show_advanced", watch=True)
+    def _update_advance_options(self):
+        if self.show_advanced:
+            logger.debug("Advanced option on.")
+            self.func_panel.display_threshold = 0.0
+        else:
+            logger.debug("Advanced option off.")
+            self.func_panel.display_threshold = 0.6
+
+    def get_task_list(self):
+        """Translate the values from widget."""
+        # grab values from panel widget
+        param_dict_shared = {
+            widget.name.lower().replace(" ", "_"): widget.value for widget in self.func_panel if widget.name != ""
+        }
+
+        # crop ct
+        param_dict_ct = {"array": "ct"}
+        param_dict_ct.update(param_dict_shared)
+        task_crop_ct = {
+            "name": "crop radiographs",
+            "function": self.func_name,
+            "inputs": param_dict_ct,
+            "outputs": ["ct"],
+        }
+
+        # crop ob
+        param_dict_ob = {"array": "ob"}
+        param_dict_ob.update(param_dict_shared)
+        task_crop_ob = {
+            "name": "crop open beams",
+            "function": self.func_name,
+            "inputs": param_dict_ob,
+            "outputs": ["ob"],
+        }
+
+        # crop dc
+        if self.crop_darkcurrent:
+            param_dict_dc = {"array": "dc"}
+            param_dict_dc.update(param_dict_shared)
+            task_crop_dc = {
+                "name": "crop dark currents",
+                "function": self.func_name,
+                "inputs": param_dict_dc,
+                "outputs": ["dc"],
+            }
+        else:
+            task_crop_dc = None
+
+        return [
+            task_crop_ct,
+            task_crop_ob,
+            task_crop_dc,
+        ]
+
+    def __panel__(self):
+        return self._panel
+
+
+if __name__ == "__main__":
+    import panel as pn
+    import holoviews as hv
+    from imars3d.ui.widgets.crop import CropWidget
+
+    pn.extension()
+    hv.extension("bokeh")
+
+    crop_widget = CropWidget()

--- a/tests/unit/ui/stages/test_dataloading.py
+++ b/tests/unit/ui/stages/test_dataloading.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-from cgi import test
 import pytest
 import shutil
 import time

--- a/tests/unit/ui/widgets/test_crop.py
+++ b/tests/unit/ui/widgets/test_crop.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+import pytest
+import time
+import panel as pn
+import holoviews as hv
+from panel.io.server import serve
+from playwright.sync_api import Page
+from imars3d.ui.widgets.crop import CropWidget
+
+pn.extension("jsoneditor")
+hv.extension("bokeh")
+
+
+@pytest.fixture(scope="module")
+def port():
+    return 1958
+
+
+def test_crop_page(page: Page, port: int):
+    import skimage
+
+    app = CropWidget(data=skimage.data.brain()[1])
+    serve(app, port=port, show=False, thread=True)
+
+    # Go to http://localhost:1958/
+    page.goto("http://localhost:1958/")
+
+    # Check input[type="checkbox"] >> nth=1
+    page.locator('input[type="checkbox"]').nth(1).check()
+    time.sleep(1)
+    # Click div:nth-child(3) > div > div > button >> nth=0
+    page.locator("div:nth-child(3) > div > div > button").first.click()
+    time.sleep(1)
+    # Click div:nth-child(5) > div > div > button >> nth=0
+    page.locator("div:nth-child(5) > div > div > button").first.click()
+    time.sleep(1)
+
+    # Click text=Advanced Options
+    page.locator("text=Advanced Options").click()
+    time.sleep(1)
+
+    # TEST ROI
+    # Click div:nth-child(8)
+    page.locator("div:nth-child(8)").click()
+    time.sleep(1)
+    # Double click div:nth-child(2) > div > div > div:nth-child(5) >> nth=0
+    page.locator("div:nth-child(2) > div > div > div:nth-child(5)").first.dblclick()
+    time.sleep(1)
+    # Double click div:nth-child(2) > div > div > div:nth-child(5) >> nth=0
+    page.locator("div:nth-child(2) > div > div > div:nth-child(5)").first.dblclick()
+    time.sleep(1)
+    # Check input[type="checkbox"] >> nth=1
+    page.locator('input[type="checkbox"]').nth(1).check()
+    time.sleep(1)
+
+    task_entry = app.get_task_list()[0]
+    print(task_entry)
+    assert task_entry["inputs"]["array"] == "ct"
+    assert task_entry["inputs"]["crop_limit"] == (127, 127, 127, 127)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])


### PR DESCRIPTION
Original Gitlab Story: [IMG290](https://code.ornl.gov/sns-hfir-scse/imaging/imaging/-/issues/290)

This PR introduces the following changes:
- a new interactive widget for interactive cropping
- a temp utility function that allows executing one single task

To test, run the following:

```python
import panel as pn
import holoviews as hv
from imars3d.ui.widgets.crop import CropWidget

pn.extension()
hv.extension('bokeh')

crop_widget = CropWidget()
# manual update the embedded config to make sure the load task
# has valid entries as we will be using those to test the widget.
crop_widget.config_dict["tasks"] = [
{
            "name": "load",
            "function": "imars3d.backend.io.data.load_data",
            "inputs": {
                "ct_dir": "/HFIR/CG1D/IPTS-25777/raw/ct_scans/iron_man",
                "ob_dir": "/HFIR/CG1D/IPTS-25777/raw/ob/Oct29_2019/",
                "dc_dir": "/HFIR/CG1D/IPTS-25777/raw/df/Oct29_2019/",
                "ct_fnmatch": "*.tiff",
                "ob_fnmatch": "*.tiff",
                "dc_fnmatch": "*.tiff"
            },
            "outputs": ["ct", "ob", "dc", "rot_angles"]
}]

crop_widget  # or pn.panel(viewer_window) or viewer_window.show() or viewer_window.servable()
```

Screenshots
----------------

![image](https://user-images.githubusercontent.com/5064852/198371908-70a93a19-5d93-4252-858e-8caeaf8d8969.png)

![image](https://user-images.githubusercontent.com/5064852/198372101-b8749430-ace5-411a-a772-f1c4b538041b.png)

![image](https://user-images.githubusercontent.com/5064852/198372160-24a429f5-c404-4e54-aa02-46a973ab2c47.png)

![image](https://user-images.githubusercontent.com/5064852/198372246-0c47a980-d95e-4779-b18e-e06b7a7ba72b.png)

