### PR TITLE
Cli entrypoint

### DIFF
--- a/docs/api/imars3d.backend.rst
+++ b/docs/api/imars3d.backend.rst
@@ -6,6 +6,9 @@ imars3d.backend package
    :undoc-members:
    :show-inheritance:
 
+.. automodule:: imars3d.backend.__main__
+
+
 Subpackages
 -----------
 

--- a/docs/users/index.rst
+++ b/docs/users/index.rst
@@ -1,3 +1,5 @@
 ===========
 User Guide
 ===========
+
+The backend can be invoked using the information in :mod:`imars3d.backend <imars3d.backend.__main__>`

--- a/setup.cfg
+++ b/setup.cfg
@@ -59,3 +59,5 @@ omit =
 
 [coverage:report]
 fail_under = 60
+exclude_lines =
+  if __name__ == "__main__":

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,6 +34,10 @@ exclude =
     tests
     notebooks
 
+[options.entry_points]
+console_scripts =
+    imars3dcli = imars3d.backend.__main__:main
+
 [options.extras_require]
 tests = pytest
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,7 +20,7 @@ classifiers =
 [options]
 include_package_data = True
 packages = find:
-python_requires = >= 3.8
+python_requires >= 3.8
 # install_requires is skipped for the following reasons:
 # 1. tomopy is not available on PyPI
 # 2. readthedoc invokes pip install with `--upgrade`, which can mess up the

--- a/src/imars3d/backend/__main__.py
+++ b/src/imars3d/backend/__main__.py
@@ -13,7 +13,9 @@ import logging
 from pathlib import Path
 
 
-def main():
+# args are exposed to allow for testing
+# passing in None causes argparse to use sys.argv
+def main(args=None):
     # set up the command line parser
     import argparse
 
@@ -31,7 +33,8 @@ def main():
         choices=["debug", "info", "warn", "error"],
         help="The log level (default: %(default)s)",
     )
-    args = parser.parse_args()
+    # configure
+    args = parser.parse_args(args)
 
     # configure logging
     logging.basicConfig(level=getattr(logging, args.log.upper()))

--- a/src/imars3d/backend/__main__.py
+++ b/src/imars3d/backend/__main__.py
@@ -1,0 +1,49 @@
+"""
+The main entry point for the back end software.
+This can be invoked using
+
+.. code-block:: sh
+
+   python -m imars3d.backend <configfile>
+
+The built-in help will give the options when supplied a ``--help`` flag.
+"""
+from imars3d.backend.workflow.engine import WorkflowEngineAuto
+import logging
+from pathlib import Path
+
+
+def main():
+    # set up the command line parser
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        prog="imars3d.backend",
+        description="Execute a workflow from a preconfigured json document",
+        epilog="https://imars3d.readthedocs.io/en/latest/",
+    )
+    parser.add_argument("configfile", type=Path)
+    parser.add_argument(
+        "-l",
+        "--log",
+        nargs="?",
+        default="info",
+        choices=["debug", "info", "warn", "error"],
+        help="The log level (default: %(default)s)",
+    )
+    args = parser.parse_args()
+
+    # configure logging
+    logging.basicConfig(level=getattr(logging, args.log.upper()))
+    logger = logging.getLogger("imars3d.backend")
+
+    # run the workflow
+    logger.info(f'Processing data using "{args.configfile}"')
+    workflow = WorkflowEngineAuto(args.configfile)
+    return workflow.run()
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(main())

--- a/src/imars3d/backend/__main__.py
+++ b/src/imars3d/backend/__main__.py
@@ -37,7 +37,10 @@ def main(args=None):
     args = parser.parse_args(args)
 
     # configure logging
-    logging.basicConfig(level=getattr(logging, args.log.upper()))
+    logging.basicConfig()  # setup default handlers and formatting
+    # override log level
+    for handler in logging.getLogger().handlers:
+        handler.setLevel(args.log.upper())
     logger = logging.getLogger("imars3d.backend")
 
     # run the workflow

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,12 @@
+from pathlib import Path
+import pytest
+
+
+@pytest.fixture(scope="session")
+def JSON_DIR():
+    return Path(__file__).parent / "data" / "json"
+
+
+@pytest.fixture(scope="session")
+def DATA_DIR():
+    return Path(__file__).parent / "data" / "imars3d-data"

--- a/tests/unit/backend/test_cli.py
+++ b/tests/unit/backend/test_cli.py
@@ -1,0 +1,20 @@
+from imars3d.backend.__main__ import main
+from pathlib import Path
+import pytest
+from json.decoder import JSONDecodeError
+
+
+def test_bad(JSON_DIR):
+    bad_json = JSON_DIR / "ill_formed.json"
+    with pytest.raises(JSONDecodeError):
+        main([str(bad_json)])
+
+
+def test_good(JSON_DIR):
+    good_json = JSON_DIR / "good_interactive.json"
+
+    main([str(good_json)])
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])

--- a/tests/unit/backend/workflow/test_validation.py
+++ b/tests/unit/backend/workflow/test_validation.py
@@ -43,7 +43,7 @@ def test_file_ill_formed():
         MockContainer(ILL_FORMED_FILE)
 
 
-@pytest.mark.parametrize("filename", [GOOD_NON_INTERACTIVE, GOOD_NON_INTERACTIVE])
+@pytest.mark.parametrize("filename", [GOOD_NON_INTERACTIVE, GOOD_INTERACTIVE])
 def test_file_good(filename):
     print("Testing file", filename)
     MockContainer(filename)


### PR DESCRIPTION
Add entrypoint for running reconstruction through the backend.

```sh
python -m imars3d.backend tests/data/json/good_non_interactive.json
```

codecov is complaining about not testing the 3 lines including `if __name__ == '__main__'`