### PR TITLE
Add CLI integration tests

### DIFF
--- a/tests/data/json/invalid_test.json
+++ b/tests/data/json/invalid_test.json
@@ -1,0 +1,16 @@
+{
+    "instrument": "cg1d",
+    "ipts": "IPTS-1234",
+    "name": "name for reconstructed ct scans",
+    "workingdir": "/path/to/dir",
+    "ouputdir": "/path/to/dir",
+    "tasks": [
+        {
+            "name": "load",
+            "function": "imars3d.backend.io.data.load_data",
+            "inputs": {
+                "filenames": []
+            }
+        }
+    ]
+}

--- a/tests/data/json/invalid_workflow.json
+++ b/tests/data/json/invalid_workflow.json
@@ -10,7 +10,7 @@
             "name": "determine_tilt_correction",
             "function": "imars3d.backend.diagnostics.tilt.tilt_correction",
             "inputs": {
-                "ct_series": "ct",
+                "arrays": "ct",
                 "rot_angles": "rot_angles"
             },
             "outputs": ["tilt_angle"]

--- a/tests/data/json/invalid_workflow.json
+++ b/tests/data/json/invalid_workflow.json
@@ -1,0 +1,36 @@
+{
+    "facility": "HFIR",
+    "instrument": "CG1D",
+    "ipts": "IPTS-1234",
+    "name": "name for reconstruced ct scans",
+    "workingdir": "/path/to/dir",
+    "outputdir": "/path/to/dir",
+    "tasks": [
+        {
+            "name": "determine_tilt_correction",
+            "function": "imars3d.backend.diagnostics.tilt.tilt_correction",
+            "inputs": {
+                "ct_series": "ct",
+                "rot_angles": "rot_angles"
+            },
+            "outputs": ["tilt_angle"]
+        },
+        {
+            "name": "tilt_corection",
+            "function": "imars3d.backend.diagnostics.tilt.apply_tilt_correction",
+            "inputs": {
+                "ct_series": "ct",
+                "angle": "determine_tilt_correction.tilt_angle"
+            },
+            "outputs": ["ct"]
+        },
+        {
+            "name": "load",
+            "function": "imars3d.backend.io.data.load_data",
+            "inputs": {
+                "filenames": []
+            },
+            "outputs": ["ct", "ob", "dc", "rot_angles"]
+        }
+    ]
+}

--- a/tests/integration/backend/test_backend.py
+++ b/tests/integration/backend/test_backend.py
@@ -4,6 +4,7 @@
 import json
 
 from imars3d.backend.workflow.engine import WorkflowEngineAuto
+from imars3d.backend.workflow.engine import WorkflowEngineError
 from imars3d.backend.workflow.validate import JSONValidationError
 import pytest
 from pathlib import Path
@@ -59,6 +60,13 @@ class TestWorkflowEngineAuto:
         INVALID_CONFIG_FILE = JSON_DATA_DIR / "invalid_test.json"
         with pytest.raises(JSONValidationError):
             with open(INVALID_CONFIG_FILE, "r") as file:
+                workflow = WorkflowEngineAuto(json.load(file))
+                workflow.run()
+
+    def test_invalid_workflow(self):
+        INVALID_WORKFLOW_FILE = JSON_DATA_DIR / "invalid_workflow.json"
+        with pytest.raises(WorkflowEngineError):
+            with open(INVALID_WORKFLOW_FILE, "r") as file:
                 workflow = WorkflowEngineAuto(json.load(file))
                 workflow.run()
 

--- a/tests/integration/backend/test_backend.py
+++ b/tests/integration/backend/test_backend.py
@@ -10,7 +10,6 @@ from pathlib import Path
 
 
 JSON_DATA_DIR = Path(__file__).parent.parent.parent / "data" / "json"
-ILL_FORMED_FILE = JSON_DATA_DIR / "ill_formed.json"
 
 
 @pytest.fixture(scope="module")
@@ -56,8 +55,10 @@ class TestWorkflowEngineAuto:
             workflow.run()
 
     def test_invalid_config(self):
+        # tests an invalid configuration (no facility present)
+        INVALID_CONFIG_FILE = JSON_DATA_DIR / "invalid_test.json"
         with pytest.raises(JSONValidationError):
-            with open(ILL_FORMED_FILE, "r") as file:
+            with open(INVALID_CONFIG_FILE, "r") as file:
                 workflow = WorkflowEngineAuto(json.load(file))
                 workflow.run()
 

--- a/tests/integration/backend/test_backend.py
+++ b/tests/integration/backend/test_backend.py
@@ -10,6 +10,7 @@ from pathlib import Path
 
 
 JSON_DATA_DIR = Path(__file__).parent.parent.parent / "data" / "json"
+ILL_FORMED_FILE = JSON_DATA_DIR / "ill_formed.json"
 
 
 @pytest.fixture(scope="module")
@@ -44,6 +45,21 @@ class TestWorkflowEngineAuto:
     def test_config(self, config):
         workflow = WorkflowEngineAuto(config)
         workflow.run()
+
+    def test_no_config(self):
+        with pytest.raises(TypeError):
+            workflow = WorkflowEngineAuto()
+            workflow.run()
+
+        with pytest.raises(json.decoder.JSONDecodeError):
+            workflow = WorkflowEngineAuto("")
+            workflow.run()
+
+    def test_invalid_config(self):
+        with pytest.raises(JSONValidationError):
+            with open(ILL_FORMED_FILE, "r") as file:
+                workflow = WorkflowEngineAuto(json.load(file))
+                workflow.run()
 
     def test_bad_filter_name_config(self):
         BAD_FILTER_JSON = JSON_DATA_DIR / "bad_filter.json"


### PR DESCRIPTION
Adds integration tests for:
- Run without any config
- Run with an invalid config (facility name missing)
- Run with an invalid workflow (load data step is last, so task inputs do not exist)

Refer to [IMG395](https://code.ornl.gov/sns-hfir-scse/imaging/imaging/-/issues/395).