### PR TITLE
Test data repository markers

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -23,9 +23,9 @@ jobs:
         run: playwright install
       - name: Install iMars3d in editable mode
         run: pip install -e .
-      - name: Unit test with code coverage
+      - name: Tests without data repository
         run: |
-          python -m pytest --cov --cov-report=xml --cov-report=term tests/unit
+          python -m pytest --cov --cov-report=xml --cov-report=term -m "not datarepo"
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
 

--- a/.github/workflows/protected_branches.yml
+++ b/.github/workflows/protected_branches.yml
@@ -17,7 +17,7 @@ jobs:
         if: ${{ github.event_name == 'workflow_dispatch' }}
         with:
           authToken: ${{secrets.GITHUB_TOKEN}}
-          context: "Integration tests"
+          context: "Tests with data repository"
           description: "pending"
           state: "pending"
           sha: "${{ github.sha }}"
@@ -31,14 +31,14 @@ jobs:
           miniforge-variant: Mambaforge
           environment-file: environment.yml
           use-mamba: true
-      - name: Unit integration tests
-        run: python -m pytest tests/integration
+      - name: Tests with data repository
+        run: python -m pytest -m datarepo
       - name: Update job status
         uses: Sibz/github-status-action@v1
         if: ${{ always() && github.event_name == 'workflow_dispatch' }}
         with:
           authToken: ${{secrets.GITHUB_TOKEN}}
-          context: "Integration tests"
+          context: "Tests with data repository"
           description: "${{ job.status }}"
           state: "${{ job.status }}"
           sha: "${{ github.sha }}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,3 +24,9 @@ file = "src/imars3d/_version.py"
 pythonpath = [
   ".", "src"
 ]
+testpaths = ["tests"]
+python_files = ["test*.py"]
+norecursedirs = [".git", "tmp*", "_tmp*", "__pycache__", "*dataset*", "*data_set*"]
+markers = [
+  "datarepo: mark a test as using imars3d-data repository"
+]

--- a/setup.cfg
+++ b/setup.cfg
@@ -49,11 +49,6 @@ ignore = E203, E266, E501, E731, W503, F403, F401
 exclude = conda.recipe/meta.yaml
 max-line-length = 120
 
-[tool:pytest]
-testpaths = tests
-python_files = *test*.py
-norecursedirs = .git tmp* _tmp* __pycache__ *dataset* *data_set*
-
 [coverage:run]
 source = src/imars3d
 omit =

--- a/tests/integration/backend/test_backend.py
+++ b/tests/integration/backend/test_backend.py
@@ -132,10 +132,12 @@ def crop_roi(slice_input):
 
 
 class TestWorkflowEngineAuto:
+    @pytest.mark.datarepo
     def test_config(self, config):
         workflow = WorkflowEngineAuto(config)
         assert workflow.config == config
 
+    @pytest.mark.datarepo
     def test_run(self, config):
         workflow = WorkflowEngineAuto(config)
         expected_slice_300 = np.load(str(DATA_DIR) + "/expected_slice_300.npy")


### PR DESCRIPTION
This moves the test selection for the builds to use a `datarepo` [pytest marker](https://docs.pytest.org/en/7.1.x/how-to/mark.html). Tests that are using the imars3d-data repository should be marked with
```py
@pytest.mark.datarepo
```
Then the tests can be run with either `python -m pytest -m datarepo` for things that require the data repository or `python -m pytest -m "not datarepo"` for things that don't. A full list of available markers can be seen using `python -m pytest --markers`