### PR TITLE
Add schema.json to the packaging

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -40,6 +40,10 @@ exclude =
 console_scripts =
     imars3dcli = imars3d.backend.__main__:main
 
+[options.package_data]
+* =
+    imars3d/backend/workflow/schema.json
+
 [options.extras_require]
 tests = pytest
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,8 +41,7 @@ console_scripts =
     imars3dcli = imars3d.backend.__main__:main
 
 [options.package_data]
-* =
-    imars3d/backend/workflow/schema.json
+* = schema.json
 
 [options.extras_require]
 tests = pytest


### PR DESCRIPTION
`imars3d/backend/workflow/schema.json` was missing from the package. To make life less painful `conda install boa` then you can repeat the build/verification of the package by doing
```
cd conda.recipe
rm -rf noarch/
conda mambabuild --output-folder . -c conda-forge .
tar tjf noarch/imars3d-**v1.0a1-py310**.tar.bz2   | grep schema.json
```
The wheel shows similar behavior
```
rm dist/imars3d*.whl
python -m build --no-isolation --wheel
unzip -l dist/imars3d*.whl
```