### PR TITLE
Move where boa is installed

### DIFF
--- a/.github/workflows/protected_branches.yml
+++ b/.github/workflows/protected_branches.yml
@@ -59,6 +59,8 @@ jobs:
           environment-file: environment.yml
       - name: Build Conda Package
         run: |
+          # boa uses mamba to resolve dependencies
+          conda install -y boa
           conda mambabuild --output-folder . -c conda-forge .
       - name: Verify Conda Package
         run: |

--- a/environment.yml
+++ b/environment.yml
@@ -4,7 +4,6 @@ channels:
   - defaults
 dependencies:
   - astropy
-  - boa
   - tomopy
   - dxchange
   - jsonschema


### PR DESCRIPTION
read-the-docs builds were timing out once boa was added to the conda environment. Move the install to within the github workflow.