### PR TITLE
[IMG448] Add thin wrapper around new ring removal method based on BM3D

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -29,3 +29,4 @@ dependencies:
     - versioningit
     - check-wheel-contents
     - pytest-playwright
+    - bm3d-streak-removal

--- a/src/imars3d/backend/corrections/ring_removal.py
+++ b/src/imars3d/backend/corrections/ring_removal.py
@@ -6,7 +6,11 @@ import param
 from imars3d.backend.util.functions import clamp_max_workers
 import scipy
 import numpy as np
-import bm3d_streak_removal as bm3dsr
+try:
+  import bm3d_streak_removal as bm3dsr
+except ImportError:
+  # add a log?
+  bm3dsr = None
 from multiprocessing.managers import SharedMemoryManager
 from tqdm.contrib.concurrent import process_map
 from functools import partial

--- a/src/imars3d/backend/corrections/ring_removal.py
+++ b/src/imars3d/backend/corrections/ring_removal.py
@@ -93,7 +93,11 @@ class bm3d_ring_removal(param.ParameterizedFunction):
 
     def __call__(self, **params):
         """See class level documentation for help."""
-        logger.info("Executing Filter: Remove Ring Artifact with BM3D")
+        if not bm3dsr:
+            logger.warning("something informative")
+            raise RuntimeError("probably same as warning")
+        else:
+            logger.info("Executing Filter: Remove Ring Artifact with BM3D")
         _ = self.instance(**params)
         params = param.ParamOverrides(self, params)
         # mangle parameters

--- a/src/imars3d/backend/corrections/ring_removal.py
+++ b/src/imars3d/backend/corrections/ring_removal.py
@@ -6,11 +6,12 @@ import param
 from imars3d.backend.util.functions import clamp_max_workers
 import scipy
 import numpy as np
+
 try:
-  import bm3d_streak_removal as bm3dsr
+    import bm3d_streak_removal as bm3dsr
 except ImportError:
-  # add a log?
-  bm3dsr = None
+    # add a log?
+    bm3dsr = None
 from multiprocessing.managers import SharedMemoryManager
 from tqdm.contrib.concurrent import process_map
 from functools import partial

--- a/src/imars3d/backend/corrections/ring_removal.py
+++ b/src/imars3d/backend/corrections/ring_removal.py
@@ -10,7 +10,6 @@ import numpy as np
 try:
     import bm3d_streak_removal as bm3dsr
 except ImportError:
-    # add a log?
     bm3dsr = None
 from multiprocessing.managers import SharedMemoryManager
 from tqdm.contrib.concurrent import process_map
@@ -23,12 +22,36 @@ class bm3d_ring_removal(param.ParameterizedFunction):
     """
     Remove ring artifact from sinograms using BM3D method.
 
+    This method requires BM3D suite, which can be installed by ``pip install bm3d_streak_removal``.
+
     ref: `10.1107/S1600577521001910 <http://doi.org/10.1107/S1600577521001910>`_
 
     Parameters
     ----------
     arrays: np.ndarray
         Input radiograph stack.
+    extreme_streak_iterations: int
+        Number of iterations for extreme streak attenuation.
+    extreme_detect_lambda: float
+        Consider streaks which are stronger than lambda * local_std as extreme.
+    extreme_detect_size: int
+        Half window size for extreme streak detection -- total (2*s + 1).
+    extreme_replace_size: int
+        Half window size for extreme streak replacement -- total (2*s + 1).
+    max_bin_iter_horizontal: int
+        The number of total horizontal scales (counting the full scale).
+    bin_vertical: int
+        The factor of vertical binning, e.g. bin_vertical=32 would perform denoising in 1/32th of the original vertical size.
+    filter_strength: float
+        Strength of BM4D denoising (>0), where 1 is the standard application, >1 is stronger, and <1 is weaker.
+    use_slices: bool
+        If True, the sinograms will be split horizontally across each binning iteration into overlapping.
+    slice_sizes: list
+        A list of horizontal sizes for use of the slicing if use_slices=True. By default, slice size is either 39 pixels or 1/5th of the total width of the current iteration, whichever is larger.
+    slice_step_sizes: list
+        List of number of pixels between slices obtained with use_slices=True, one for each binning iteration. By default 1/4th of the corresponding slice size.
+    denoise_indices: list
+        Indices of sinograms to denoise; by default, denoises the full stack provided.
 
     Returns
     -------
@@ -94,8 +117,8 @@ class bm3d_ring_removal(param.ParameterizedFunction):
     def __call__(self, **params):
         """See class level documentation for help."""
         if not bm3dsr:
-            logger.warning("something informative")
-            raise RuntimeError("probably same as warning")
+            logger.warning("To use method, make sure to install bm3d_streak_removal package via pip.")
+            raise RuntimeError("BM3D suite not installed, please install with pip install bm3d_streak_removal")
         else:
             logger.info("Executing Filter: Remove Ring Artifact with BM3D")
         _ = self.instance(**params)

--- a/tests/unit/backend/corrections/test_ring_removal.py
+++ b/tests/unit/backend/corrections/test_ring_removal.py
@@ -5,10 +5,11 @@ import tomopy
 from imars3d.backend.corrections.ring_removal import remove_ring_artifact
 from imars3d.backend.corrections.ring_removal import remove_ring_artifact_Ketcham
 from imars3d.backend.corrections.ring_removal import bm3d_ring_removal
+
 try:
-  import bm3d_streak_removal as bm3dsr
+    import bm3d_streak_removal as bm3dsr
 except ImportError:
-  bm3dsr = None
+    bm3dsr = None
 
 
 def get_synthetic_stack(N_omega: int = 181, size: int = 200) -> np.ndarray:

--- a/tests/unit/backend/corrections/test_ring_removal.py
+++ b/tests/unit/backend/corrections/test_ring_removal.py
@@ -5,6 +5,10 @@ import tomopy
 from imars3d.backend.corrections.ring_removal import remove_ring_artifact
 from imars3d.backend.corrections.ring_removal import remove_ring_artifact_Ketcham
 from imars3d.backend.corrections.ring_removal import bm3d_ring_removal
+try:
+  import bm3d_streak_removal as bm3dsr
+except ImportError:
+  bm3dsr = None
 
 
 def get_synthetic_stack(N_omega: int = 181, size: int = 200) -> np.ndarray:

--- a/tests/unit/backend/corrections/test_ring_removal.py
+++ b/tests/unit/backend/corrections/test_ring_removal.py
@@ -4,11 +4,12 @@ import pytest
 import tomopy
 from imars3d.backend.corrections.ring_removal import remove_ring_artifact
 from imars3d.backend.corrections.ring_removal import remove_ring_artifact_Ketcham
+from imars3d.backend.corrections.ring_removal import bm3d_ring_removal
 
 
-def get_synthetic_stack(N_omega: int = 181) -> np.ndarray:
+def get_synthetic_stack(N_omega: int = 181, size: int = 200) -> np.ndarray:
     omegas = np.linspace(0, np.pi * 2, N_omega)
-    shepp3d = tomopy.misc.phantom.shepp3d(size=200)
+    shepp3d = tomopy.misc.phantom.shepp3d(size=size)
     # use emission type radiograph to skip the -log step
     projs = tomopy.sim.project.project(shepp3d, omegas, emission=True)
     return projs
@@ -59,6 +60,33 @@ def test_remove_ring_artifact_Ketcham():
     err_no_correction = np.linalg.norm(sino - sino_ref) / sino.size
     err_correction = np.linalg.norm(sino_corrected - sino_ref) / sino.size
     assert err_correction < err_no_correction
+
+
+def test_bm3d_ring_removal():
+    # step_0: prepare synthetic data
+    # note: we need a tiny test data as bm3d is very slow
+    tomo_ideal = get_synthetic_stack(N_omega=21, size=32)
+    # mimic the absorption graph
+    tomo_ideal = 1.0 - tomo_ideal / tomo_ideal.max()
+    # add white noise
+    mean = 0.0
+    sigma = 1e-2
+    tomo_noisy = tomo_ideal + np.random.normal(mean, sigma, tomo_ideal.shape)
+    tomo_noisy = np.nan_to_num(np.log(tomo_noisy), nan=0.0, posinf=0.0, neginf=0.0)
+    tomo_ideal = np.nan_to_num(np.log(tomo_ideal), nan=0.0, posinf=0.0, neginf=0.0)
+    # the streak in sinogram cannot exceed +-0.05
+    tomo_noisy_ringy = np.array(tomo_noisy)
+    mean = 0.0
+    sigma = 1e-2  # use smaller value to ensure the streak is not overwhelming
+    for i in range(tomo_noisy_ringy.shape[1]):
+        streak_noise_component = np.random.normal(mean, sigma, tomo_noisy_ringy.shape[2])
+        tomo_noisy_ringy[:, i, :] = tomo_noisy_ringy[:, i, :] + streak_noise_component
+    # step_1: run correction
+    tomo_corrected = bm3d_ring_removal(arrays=tomo_noisy_ringy)
+    # step_2: verify
+    score_ref = np.median(np.absolute(tomo_noisy_ringy - tomo_ideal))
+    score_corr = np.median(np.absolute(tomo_corrected - tomo_ideal))
+    assert score_corr < score_ref
 
 
 if __name__ == "__main__":

--- a/tests/unit/backend/corrections/test_ring_removal.py
+++ b/tests/unit/backend/corrections/test_ring_removal.py
@@ -66,6 +66,7 @@ def test_remove_ring_artifact_Ketcham():
     assert err_correction < err_no_correction
 
 
+@pytest.mark.skipif(not bm3dsr, reason="something meaningful array")
 def test_bm3d_ring_removal():
     # step_0: prepare synthetic data
     # note: we need a tiny test data as bm3d is very slow

--- a/tests/unit/backend/corrections/test_ring_removal.py
+++ b/tests/unit/backend/corrections/test_ring_removal.py
@@ -67,7 +67,7 @@ def test_remove_ring_artifact_Ketcham():
     assert err_correction < err_no_correction
 
 
-@pytest.mark.skipif(not bm3dsr, reason="something meaningful array")
+@pytest.mark.skipif(not bm3dsr, reason="bm3d not installed, skipping test.")
 def test_bm3d_ring_removal():
     # step_0: prepare synthetic data
     # note: we need a tiny test data as bm3d is very slow


### PR DESCRIPTION
- Original Gitlab Story: [IMG448](https://code.ornl.gov/sns-hfir-scse/imaging/imaging/-/issues/448)

This PR introduces a thin wrapper around a new ring artifact removal (`bm3d_streak_removal`).