### PR TITLE
Trouble shoot CI failure related to Github mamba solution

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: conda-incubator/setup-miniconda@v2
         with:
           auto-update-conda: true
-          mamba-version: "*"
+          mamba-version: "0.15"
           environment-file: environment.yml
       - name: Verify docstrings
         run: pydocstyle --convention=numpy src/

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -18,8 +18,9 @@ jobs:
       - uses: conda-incubator/setup-miniconda@v2
         with:
           auto-update-conda: true
-          mamba-version: "0.15"
+          mamba-version: "*"
           environment-file: environment.yml
+          python-version: 3.9
       - name: Verify docstrings
         run: pydocstyle --convention=numpy src/
       - name: Install ui test requirements

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -18,9 +18,8 @@ jobs:
       - uses: conda-incubator/setup-miniconda@v2
         with:
           auto-update-conda: true
-          mamba-version: "*"
+          miniforge-version: latest
           environment-file: environment.yml
-          python-version: 3.9
       - name: Verify docstrings
         run: pydocstyle --convention=numpy src/
       - name: Install ui test requirements

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -42,7 +42,7 @@ jobs:
       - uses: conda-incubator/setup-miniconda@v2
         with:
           auto-update-conda: true
-          mamba-version: "*"
+          miniforge-version: latest
           environment-file: environment.yml
       - name: Build Wheel
         run: python -m build --no-isolation --wheel

--- a/.github/workflows/protected_branches.yml
+++ b/.github/workflows/protected_branches.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           miniconda-version: "latest"
           auto-update-conda: true
-          mamba-version: "*"
+          miniforge-version: latest
           environment-file: environment.yml
       - name: Tests with data repository
         run: python -m pytest -m datarepo
@@ -57,7 +57,7 @@ jobs:
       - uses: conda-incubator/setup-miniconda@v2
         with:
           auto-update-conda: true
-          mamba-version: "*"
+          miniforge-version: latest
           environment-file: environment.yml
       - name: Build Conda Package
         run: |


### PR DESCRIPTION
The issue is at the upstream where the provider's mamba solution is also failing (https://github.com/conda-incubator/setup-miniconda/actions/runs/3944571519/jobs/6750622433).

The goal here is to find a temp solution until the provider fixes their issue.

The workaround solution is found in this issue: https://github.com/conda-incubator/setup-miniconda/issues/274