### PR TITLE
remove conflicting opts

### DIFF
--- a/.github/workflows/protected_branches.yml
+++ b/.github/workflows/protected_branches.yml
@@ -29,7 +29,6 @@ jobs:
           lfs: true
       - uses: conda-incubator/setup-miniconda@v2
         with:
-          miniconda-version: "latest"
           auto-update-conda: true
           miniforge-version: latest
           environment-file: environment.yml


### PR DESCRIPTION
In the protected branch ci file, `mimiconda-version` is conflicting with `mini-forge`.
This PR removes the conflicting options.