### PR TITLE
upgrade branch-mapper to v2

### DIFF
--- a/.github/workflows/protected_branches.yml
+++ b/.github/workflows/protected_branches.yml
@@ -86,7 +86,7 @@ jobs:
     if: ${{ github.ref_protected || github.ref_type == 'tag' }}
     steps:
       - name: Determine Environment
-        uses: neutrons/branch-mapper@main
+        uses: neutrons/branch-mapper@v2
         id: conda_env_name
         with:
           prefix: imars3d


### PR DESCRIPTION
Simple PR to update the `branch-mapper` to v2.

> it is not possible to test the change as it is only used in the final deployment step, which is a restricted step.