### PR TITLE
switch to use the reader from tifffile directly

### DIFF
--- a/src/imars3d/backend/dataio/data.py
+++ b/src/imars3d/backend/dataio/data.py
@@ -254,7 +254,10 @@ def _load_images(filelist: List[str], desc: str, max_workers: int, tqdm_class) -
     # figure out the file type and select corresponding reader from dxchange
     file_ext = Path(filelist[0]).suffix.lower()
     if file_ext in (".tif", ".tiff"):
-        reader = dxchange.read_tiff
+        # reader = dxchange.read_tiff
+        # NOTE: switch to tifffile until we figure out what is causing dxchange
+        #       to slow down the loading speed.
+        reader = tifffile.imread
     elif file_ext == ".fits":
         reader = dxchange.read_fits
     else:


### PR DESCRIPTION
This PR switch the reader for tiff file from the dxchange wrapper to the one from tifffile directly.

> IBM item: [Story1209](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=1209&tab=com.ibm.team.workitem.tab.links)