### PR TITLE
Add log file entry to backend engine

### DIFF
--- a/src/imars3d/backend/workflow/engine.py
+++ b/src/imars3d/backend/workflow/engine.py
@@ -11,6 +11,8 @@ from collections import namedtuple
 from enum import Enum
 import importlib
 from typing import Any, Optional
+from pathlib import Path
+import logging
 
 
 class WorkflowEngineExitCodes(Enum):
@@ -238,6 +240,20 @@ class WorkflowEngineAuto(WorkflowEngine):
 
     def run(self) -> None:
         r"""Sequential execution of the tasks specified in the JSON configuration file."""
+        # set the logger file if it is specified in the configuration
+        log_file_name = self.config.get("log_file_name", "")
+        if log_file_name:
+            # create log file to capture the root logger, in order to also capture messages from the backend
+            log_file_path = Path(log_file_name)
+            log_file_handler = logging.FileHandler(log_file_path)
+            log_file_handler.setLevel(logging.INFO)
+            # set formatter
+            formatter = logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
+            log_file_handler.setFormatter(formatter)
+            # add handler to root logger
+            root_logger = logging.getLogger()
+            root_logger.addHandler(log_file_handler)
+        # verify the inputs are sensible
         self._dryrun()
         # initialize the registry of global parameters with the metadata
         self._registry = {k: v for k, v in self.config.items() if k not in ("name", "tasks")}

--- a/src/imars3d/backend/workflow/engine.py
+++ b/src/imars3d/backend/workflow/engine.py
@@ -248,7 +248,7 @@ class WorkflowEngineAuto(WorkflowEngine):
             log_file_handler = logging.FileHandler(log_file_path)
             log_file_handler.setLevel(logging.INFO)
             # set formatter
-            formatter = logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
+            formatter = logging.Formatter("[%(levelname)s] - %(asctime)s - %(name)s - %(message)s")
             log_file_handler.setFormatter(formatter)
             # add handler to root logger
             root_logger = logging.getLogger()

--- a/tests/data/json/good_non_interactive_full.json
+++ b/tests/data/json/good_non_interactive_full.json
@@ -5,6 +5,7 @@
     "name": "name for reconstructed ct scans",
     "workingdir": "/path/to/working/dir",
     "outputdir": "/tmp/imars3d/",
+    "log_file_name": "/tmp/test_run.log",
     "tasks": [{
             "name": "task1",
             "function": "imars3d.backend.dataio.data.load_data",


### PR DESCRIPTION
This PR introduces the following changes:

- Allow user to specify a log file to duplicate logging stream.
- Example json file is updated to reflect the change.


> EWM item: [Story4308](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=4308)