### PR TITLE
Add support for TOF imaging

### DIFF
--- a/src/imars3d/backend/corrections/beam_hardening.py
+++ b/src/imars3d/backend/corrections/beam_hardening.py
@@ -4,7 +4,7 @@
 import logging
 import param
 import numpy as np
-from imars3d.backend.util.functions import clamp_max_workers
+from imars3d.backend.util.functions import clamp_max_workers, calculate_chunksize
 from multiprocessing.managers import SharedMemoryManager
 from functools import partial
 from tqdm.contrib.concurrent import process_map
@@ -83,6 +83,7 @@ class beam_hardening_correction(param.ParameterizedFunction):
                 # mp
                 kwargs = {
                     "max_workers": self.max_workers,
+                    "chunksize": calculate_chunksize(params.arrays.shape[0], self.max_workers),
                     "desc": "denoise_by_bilateral",
                 }
                 if self.tqdm_class:

--- a/src/imars3d/backend/corrections/denoise.py
+++ b/src/imars3d/backend/corrections/denoise.py
@@ -3,7 +3,7 @@
 """Image noise reduction (denoise) module."""
 import logging
 import param
-from imars3d.backend.util.functions import clamp_max_workers
+from imars3d.backend.util.functions import clamp_max_workers, calculate_chunksize
 import numpy as np
 import tomopy
 from multiprocessing.managers import SharedMemoryManager
@@ -153,6 +153,7 @@ def denoise_by_bilateral(
             # mp
             kwargs = {
                 "max_workers": max_workers,
+                "chunksize": calculate_chunksize(arrays.shape[0], max_workers),
                 "desc": "denoise_by_bilateral",
             }
             if tqdm_class:

--- a/src/imars3d/backend/corrections/intensity_fluctuation_correction.py
+++ b/src/imars3d/backend/corrections/intensity_fluctuation_correction.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 """iMars3D's intensity fluctuation correction module."""
 import logging
-from imars3d.backend.util.functions import clamp_max_workers
+from imars3d.backend.util.functions import clamp_max_workers, calculate_chunksize
 import numpy as np
 import param
 import tomopy
@@ -93,6 +93,7 @@ class intensity_fluctuation_correction(param.ParameterizedFunction):
                 # map the multiprocessing calls
                 kwargs = {
                     "max_workers": max_workers,
+                    "chunksize": calculate_chunksize(ct.shape[0], max_workers),
                     "desc": "intensity_fluctuation_correction",
                 }
                 if tqdm_class:

--- a/src/imars3d/backend/corrections/ring_removal.py
+++ b/src/imars3d/backend/corrections/ring_removal.py
@@ -3,7 +3,7 @@
 """iMars3D's ring artifact correction module."""
 import logging
 import param
-from imars3d.backend.util.functions import clamp_max_workers
+from imars3d.backend.util.functions import clamp_max_workers, calculate_chunksize
 import scipy
 import numpy as np
 
@@ -238,6 +238,7 @@ class remove_ring_artifact(param.ParameterizedFunction):
             # invoke mp via tqdm wrapper
             kwargs = {
                 "max_workers": max_workers,
+                "chunksize": calculate_chunksize(arrays.shape[1], max_workers),
                 "desc": "Removing ring artifact",
             }
             if tqdm_class:

--- a/src/imars3d/backend/dataio/data.py
+++ b/src/imars3d/backend/dataio/data.py
@@ -125,6 +125,9 @@ class load_data(param.ParameterizedFunction):
 
         Currently, we are using a forgiving reader to load the image where a corrupted file
         will not block reading other data.
+
+        The rotation angles are extracted from the filenames if possible, otherwise from the
+        metadata embedded in the tiff files. If both failed, the angle will be set to None.
     """
 
     #
@@ -544,7 +547,7 @@ def _get_filelist_by_dir(
 def _extract_rotation_angles(
     filelist: List[str],
     metadata_idx: int = 65039,
-) -> np.ndarray:
+) -> Optional[np.ndarray]:
     """
     Extract rotation angles in degrees from filename or metadata.
 
@@ -558,40 +561,106 @@ def _extract_rotation_angles(
     Returns
     -------
         rotation_angles
+            Array of rotation angles if successfully extracted, None otherwise.
     """
     # sanity check
-    if filelist == []:
+    if not filelist:
         logger.error("filelist is [].")
         raise ValueError("filelist cannot be empty list.")
 
-    # extract rotation angles from file names
+    # process one file at a time
+    rotation_angles = []
+    for filename in filelist:
+        file_ext = Path(filename).suffix.lower()
+        angle = None
+        if file_ext == ".tiff":
+            # first, let's try to extract the angle from the filename
+            angle = extract_rotation_angle_from_filename(filename)
+            if angle is None:
+                # if failed, try to extract from metadata
+                angle = extract_rotation_angle_from_tiff_metadata(filename, metadata_idx)
+            if angle is None:
+                # if failed, log a warning and move on
+                logger.warning(f"Failed to extract rotation angle from {filename}.")
+        elif file_ext in (".tif", ".fits"):
+            # for tif and fits, we can only extract from filename as the metadata is not reliable
+            angle = extract_rotation_angle_from_filename(filename)
+            if angle is None:
+                # if failed, log a warning and move on
+                logger.warning(f"Failed to extract rotation angle from {filename}.")
+        else:
+            # if the file type is not supported, raise value error
+            logger.error(f"Unsupported file type: {file_ext}")
+            raise ValueError("Unsupported file type.")
+
+        rotation_angles.append(angle)
+
+    # this means we have a list of None
+    if all(angle is None for angle in rotation_angles):
+        logger.warning("Failed to extract any rotation angles.")
+        return None
+
+    # warn users if some angles are missing
+    if any(angle is None for angle in rotation_angles):
+        logger.warning("Some rotation angles are missing. You will see nan in the rotation angles array.")
+
+    return np.array(rotation_angles, dtype=float)
+
+
+def extract_rotation_angle_from_filename(filename: str) -> Optional[float]:
+    """
+    Extract rotation angle in degrees from filename.
+
+    Parameters
+    ----------
+    filename:
+        Filename to extract rotation angle from.
+
+    Returns
+    -------
+        rotation_angle
+            Rotation angle in degrees if successfully extracted, None otherwise.
+    """
+    # extract rotation angle from file names
     # Note
     # ----
     #   For the following file
     #       20191030_ironman_small_0070_300_440_0520.tif(f)
+    #       20191030_ironman_small_0070_300_440_0520.fits
     #   the rotation angle is 300.44 degrees
-    # If all given filenames follows the pattern, we will use the angles from
-    # filenames. Otherwise, we will use the angles from metadata.
-    regex = r"\d{8}_\S*_\d{4}_(?P<deg>\d{3})_(?P<dec>\d{3})_\d*\.tif{1,2}"
-    matches = [re.match(regex, Path(f).name) for f in filelist]
-    if all(matches):
-        logger.info("Using rotation angles from filenames.")
-        rotation_angles = np.array([float(".".join(m.groups())) for m in matches])
+    regex = r"\d{8}_\S*_\d{4}_(?P<deg>\d{3})_(?P<dec>\d{3})_\d*\.(?:tiff?|fits)"
+    match = re.match(regex, Path(filename).name)
+    if match:
+        rotation_angle = float(".".join(match.groups()))
     else:
-        # extract rotation angles from metadata
-        file_exts = set(Path(f).suffix.lower() for f in filelist)
-        if not file_exts.issubset({".tiff", ".tif"}):
-            logger.error("Only .tiff and .tif files are supported.")
-            raise ValueError("Rotation angle from metadata is only supported for .tiff and .tif files.")
+        rotation_angle = None
+    return rotation_angle
+
+
+def extract_rotation_angle_from_tiff_metadata(filename: str, metadata_idx: int = 65039) -> Optional[float]:
+    """
+    Extract rotation angle in degrees from metadata of a tiff file.
+
+    Parameters
+    ----------
+    filename:
+        Filename to extract rotation angle from.
+    metadata_idx:
+        Index of metadata to extract rotation angle from, default is 65039.
+
+    Returns
+    -------
+        rotation_angle
+            Rotation angle in degrees if successfully extracted, None otherwise.
+    """
+    try:
         # -- read metadata
         # img = tifffile.TiffFile("test_with_metadata_0.tiff")
         # img.pages[0].tags[65039].value
         # >> 'RotationActual:0.579840'
-        rotation_angles = np.array(
-            [float(tifffile.TiffFile(f).pages[0].tags[metadata_idx].value.split(":")[-1]) for f in filelist],
-            dtype="float",
-        )
-    return rotation_angles
+        return float(tifffile.TiffFile(filename).pages[0].tags[metadata_idx].value.split(":")[-1])
+    except Exception:
+        return None
 
 
 def _save_data(filename: Path, data: np.ndarray, rot_angles: np.ndarray = None) -> None:

--- a/src/imars3d/backend/dataio/data.py
+++ b/src/imars3d/backend/dataio/data.py
@@ -568,21 +568,21 @@ def _extract_rotation_angles(
     # Note
     # ----
     #   For the following file
-    #       20191030_ironman_small_0070_300_440_0520.tiff
+    #       20191030_ironman_small_0070_300_440_0520.tif(f)
     #   the rotation angle is 300.44 degrees
     # If all given filenames follows the pattern, we will use the angles from
     # filenames. Otherwise, we will use the angles from metadata.
-    regex = r"\d{8}_\S*_\d{4}_(?P<deg>\d{3})_(?P<dec>\d{3})_\d*\.tiff"
+    regex = r"\d{8}_\S*_\d{4}_(?P<deg>\d{3})_(?P<dec>\d{3})_\d*\.tif{1,2}"
     matches = [re.match(regex, Path(f).name) for f in filelist]
     if all(matches):
         logger.info("Using rotation angles from filenames.")
         rotation_angles = np.array([float(".".join(m.groups())) for m in matches])
     else:
         # extract rotation angles from metadata
-        file_ext = set([Path(f).suffix for f in filelist])
-        if file_ext != {".tiff"}:
-            logger.error("Only tiff files are supported.")
-            raise ValueError("Rotation angle from metadata is only supported for Tiff.")
+        file_exts = set(Path(f).suffix.lower() for f in filelist)
+        if not file_exts.issubset({".tiff", ".tif"}):
+            logger.error("Only .tiff and .tif files are supported.")
+            raise ValueError("Rotation angle from metadata is only supported for .tiff and .tif files.")
         # -- read metadata
         # img = tifffile.TiffFile("test_with_metadata_0.tiff")
         # img.pages[0].tags[65039].value

--- a/src/imars3d/backend/dataio/data.py
+++ b/src/imars3d/backend/dataio/data.py
@@ -592,7 +592,7 @@ def _extract_rotation_angles(
         else:
             # if the file type is not supported, raise value error
             logger.error(f"Unsupported file type: {file_ext}")
-            raise ValueError("Unsupported file type.")
+            raise ValueError(f"Unsupported file type: {file_ext}")
 
         rotation_angles.append(angle)
 

--- a/src/imars3d/backend/dataio/data.py
+++ b/src/imars3d/backend/dataio/data.py
@@ -3,7 +3,7 @@
 
 # package imports
 from imars3d.backend.dataio.metadata import MetaData
-from imars3d.backend.util.functions import clamp_max_workers, to_time_str
+from imars3d.backend.util.functions import clamp_max_workers, to_time_str, calculate_chunksize
 
 # third party imports
 import numpy as np
@@ -329,6 +329,7 @@ def _load_images(filelist: List[str], desc: str, max_workers: int, tqdm_class) -
         #       - there are a lot of cores available
         kwargs = {
             "max_workers": max_workers,
+            "chunksize": calculate_chunksize(len(filelist), max_workers),
             "desc": desc,
         }
         rst = process_map(partial(_forgiving_reader, reader=reader), filelist, **kwargs)

--- a/src/imars3d/backend/dataio/data.py
+++ b/src/imars3d/backend/dataio/data.py
@@ -296,7 +296,17 @@ def _load_images(filelist: List[str], desc: str, max_workers: int, tqdm_class) -
     file_ext = Path(filelist[0]).suffix.lower()
     if file_ext in (".tif", ".tiff"):
         # use tifffile directly for a faster loading
-        reader = partial(tifffile.imread, out="memmap")
+        # NOTE: Test conducted on 09-05-2024 on bl10-analysis1 shows that using
+        #       memmap is faster, which contradicts the observation from the instrument
+        #       team.
+        #                       | Method | Time (s) |
+        #                       |--------|----------|
+        #                       | `imread(out="memmap")` | 2.62 s ± 24.6 ms |
+        #                       | `imread()` | 3.59 s ± 13.6 ms |
+        #       The `memmap` option is removed until we have a better understanding of the
+        #       discrepancy.
+        # reader = partial(tifffile.imread, out="memmap")
+        reader = tifffile.imread
     elif file_ext == ".fits":
         reader = dxchange.read_fits
     else:

--- a/src/imars3d/backend/diagnostics/rotation.py
+++ b/src/imars3d/backend/diagnostics/rotation.py
@@ -5,7 +5,7 @@ import logging
 import numpy as np
 
 import param
-from imars3d.backend.util.functions import clamp_max_workers
+from imars3d.backend.util.functions import clamp_max_workers, calculate_chunksize
 from multiprocessing.managers import SharedMemoryManager
 from tqdm.contrib.concurrent import process_map
 from tomopy.recon.rotation import find_center_pc
@@ -139,6 +139,7 @@ class find_rotation_center(param.ParameterizedFunction):
             # map the multiprocessing calls
             kwargs = {
                 "max_workers": max_workers,
+                "chunksize": calculate_chunksize(len(idx_low), max_workers),
                 "desc": "Finding rotation center",
             }
             if tqdm_class:

--- a/src/imars3d/backend/diagnostics/tilt.py
+++ b/src/imars3d/backend/diagnostics/tilt.py
@@ -4,7 +4,7 @@
 import logging
 import param
 import multiprocessing
-from imars3d.backend.util.functions import clamp_max_workers
+from imars3d.backend.util.functions import clamp_max_workers, calculate_chunksize
 import numpy as np
 from typing import Tuple, Union, Optional
 from functools import partial
@@ -336,6 +336,7 @@ class tilt_correction(param.ParameterizedFunction):
 
             kwargs = {
                 "max_workers": self.max_workers,
+                "chunksize": calculate_chunksize(len(idx_lowrange), self.max_workers),
                 "desc": "Calculating tilt correction",
             }
             if params.tqdm_class:
@@ -442,6 +443,7 @@ class apply_tilt_correction(param.ParameterizedFunction):
                 np.copyto(shm_arrays, params.arrays)
                 kwargs = {
                     "max_workers": self.max_workers,
+                    "chunksize": calculate_chunksize(params.arrays.shape[0], self.max_workers),
                     "desc": "Applying tilt corr",
                 }
                 if params.tqdm_class:

--- a/src/imars3d/backend/util/functions.py
+++ b/src/imars3d/backend/util/functions.py
@@ -16,6 +16,15 @@ def clamp_max_workers(max_workers: Union[int, None]) -> int:
     """Calculate the number of max workers.
 
     If it isn't specified, return something appropriate for the system.
+
+    Parameters
+    ----------
+    max_workers:
+        The maximum number of workers to use
+
+    Returns
+    -------
+        The number of maximum
     """
     if max_workers is None:
         max_workers = 0
@@ -32,13 +41,18 @@ def clamp_max_workers(max_workers: Union[int, None]) -> int:
 def calculate_chunksize(num_elements: int, max_workers: Union[int, None] = None, scale_factor: int = 4) -> int:
     """Calculate an optimal chunk size for multiprocessing.
 
-    Parameters:
-    - num_elements: The total number of elements to process.
-    - max_workers: The number of workers (processes) to use. Defaults to clamped max.
-    - scale_factor: A factor to fine-tune chunk size (default 4).
+    Parameters
+    ----------
+    num_elements:
+        The number of elements to process
+    max_workers:
+        The maximum number of workers to use
+    scale_factor:
+        The factor to scale the chunk size by
 
-    Returns:
-    - int: Suggested chunk size.
+    Returns
+    -------
+        The optimal chunk size
     """
     # Calculate the number of workers
     workers = clamp_max_workers(max_workers)

--- a/src/imars3d/backend/util/functions.py
+++ b/src/imars3d/backend/util/functions.py
@@ -38,7 +38,7 @@ def clamp_max_workers(max_workers: Union[int, None]) -> int:
     return result
 
 
-def calculate_chunksize(num_elements: int, max_workers: Union[int, None] = None, scale_factor: int = 4) -> int:
+def calculate_chunksize(num_elements: int, max_workers: Optional[int] = None, scale_factor: int = 4) -> int:
     """Calculate an optimal chunk size for multiprocessing.
 
     Parameters

--- a/src/imars3d/backend/util/functions.py
+++ b/src/imars3d/backend/util/functions.py
@@ -6,7 +6,7 @@ from datetime import datetime
 import logging
 import multiprocessing
 import resource
-from typing import Union
+from typing import Optional, Union
 
 
 logger = logging.getLogger(__name__)

--- a/src/imars3d/backend/util/functions.py
+++ b/src/imars3d/backend/util/functions.py
@@ -29,6 +29,26 @@ def clamp_max_workers(max_workers: Union[int, None]) -> int:
     return result
 
 
+def calculate_chunksize(num_elements: int, max_workers: Union[int, None] = None, scale_factor: int = 4) -> int:
+    """Calculate an optimal chunk size for multiprocessing.
+
+    Parameters:
+    - num_elements: The total number of elements to process.
+    - max_workers: The number of workers (processes) to use. Defaults to clamped max.
+    - scale_factor: A factor to fine-tune chunk size (default 4).
+
+    Returns:
+    - int: Suggested chunk size.
+    """
+    # Calculate the number of workers
+    workers = clamp_max_workers(max_workers)
+
+    # Calculate chunk size based on number of elements and workers
+    chunksize = max(1, num_elements // (workers * scale_factor))
+
+    return chunksize
+
+
 def to_time_str(value: datetime = datetime.now()) -> str:
     """
     Convert the supplied datetime to a formatted string.

--- a/tests/unit/backend/preparation/test_normalization.py
+++ b/tests/unit/backend/preparation/test_normalization.py
@@ -124,6 +124,24 @@ def test_normalization_bright_dark():
     assert diff < 0.01
 
 
+def test_normalization_no_darks():
+    """Test normalization routine without providing dark field images."""
+    raw, _, flats, proj = prepare_synthetic_data()
+
+    # Process with normalization, passing None for darks
+    proj_imars3d = normalization(arrays=raw, flats=flats, darks=None)
+
+    # Compare results
+    diff = np.absolute(proj_imars3d - proj).sum() / np.prod(proj.shape)
+    assert diff < 0.02  # Increased tolerance from 0.01 to 0.02 to account for the lack of dark field images
+
+    # Additional check: Ensure the shape of the output matches the input
+    assert proj_imars3d.shape == raw.shape
+
+    # Check that values are within expected range (0 to 1 for normalized data)
+    assert np.all(proj_imars3d >= 0) and np.all(proj_imars3d <= 1)
+
+
 class TestMinusLog:
     @pytest.mark.parametrize("ncore", [1, 2])
     def test_execution(self, ncore: int) -> None:

--- a/tests/unit/backend/util/test_util.py
+++ b/tests/unit/backend/util/test_util.py
@@ -1,8 +1,9 @@
 # package imports
-from imars3d.backend.util.functions import clamp_max_workers, to_time_str
+from imars3d.backend.util.functions import clamp_max_workers, to_time_str, calculate_chunksize
 
 # third party imports
 import pytest
+from unittest.mock import patch
 
 # standard imports
 from datetime import datetime
@@ -11,6 +12,51 @@ from datetime import datetime
 def test_clamp_max_workers():
     assert clamp_max_workers(10) >= 1
     assert clamp_max_workers(-10) >= 1
+
+
+@patch("multiprocessing.cpu_count", return_value=8)
+def test_chunksize_with_small_number_of_elements(mock_cpu_count):
+    num_elements = 10
+    max_workers = None
+    chunksize = calculate_chunksize(num_elements, max_workers)
+    assert chunksize == 1
+
+
+@patch("multiprocessing.cpu_count", return_value=8)
+def test_chunksize_with_large_number_of_elements(mock_cpu_count):
+    num_elements = 10000
+    max_workers = None
+    chunksize = calculate_chunksize(num_elements, max_workers)
+    expected_chunksize = max(1, num_elements // (6 * 4))  # 6 workers, scale factor 4
+    assert chunksize == expected_chunksize
+
+
+@patch("multiprocessing.cpu_count", return_value=4)
+def test_chunksize_with_different_cpu_count(mock_cpu_count):
+    num_elements = 10000
+    max_workers = None
+    chunksize = calculate_chunksize(num_elements, max_workers)
+    expected_chunksize = max(1, num_elements // (2 * 4))  # 2 workers (cpu_count - 2), scale factor 4
+    assert chunksize == expected_chunksize
+
+
+@patch("multiprocessing.cpu_count", return_value=8)
+def test_chunksize_with_max_workers(mock_cpu_count):
+    num_elements = 10000
+    max_workers = 4
+    chunksize = calculate_chunksize(num_elements, max_workers)
+    expected_chunksize = max(1, num_elements // (4 * 4))  # 4 workers manually set
+    assert chunksize == expected_chunksize
+
+
+@patch("multiprocessing.cpu_count", return_value=8)
+def test_chunksize_with_custom_scale_factor(mock_cpu_count):
+    num_elements = 10000
+    max_workers = None
+    scale_factor = 2
+    chunksize = calculate_chunksize(num_elements, max_workers, scale_factor=scale_factor)
+    expected_chunksize = max(1, num_elements // (6 * 2))  # 6 workers, scale factor 2
+    assert chunksize == expected_chunksize
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This PR introduces this following changes:

- Disable `memmap` (the instrument team reported that it is slowing down the reading)
- Both `.tiff` and `.tif` are considered valid extension for TIFF input format now
- During normalization, one can specify `darks=None` to assume perfect dark fields (all dark fields are zero)
- The data loader now attempts to extract rotation angles from files, returning `None` if extraction fails. For files with partially missing rotation angles, the loader will return `np.nan` in the rotation angle list, allowing users to handle or sanitize the missing values as needed. While files must still adhere to the correct naming pattern (or contain the necessary metadata) for auto reduction, the auto reconstruction process will no longer fail if rotation angle extraction is unsuccessful.
- The tilt correction functionality now allows users to specify the rotation center for tilt. By default, iMars3D is assuming the center of the image is the rotation center for tilt correction. Users can overwrite this by providing the actual rotation center as a tuple to tilt related functions.
- Add a new function to calculate the chunk size for tqdm multi-processing wrapper. This is to resolve the warning about too many chunks when processing large number of images.


> EWM story: [6746](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=6746)